### PR TITLE
feat(cloud): add support for Japanese Toshiba IOLife devices

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -1089,7 +1089,10 @@ class MideaAirCloud(MideaCloud):
 
 
 _IOLIFE_APP_VERSION = "3.4.0"
-# All Toshiba IoLife devices carry manufacturer code 0x0008.
+# All Toshiba IoLife devices carry manufacturer code 0x0008 -- the same value the
+# app ships as APP_ENTERPRISE and the prefix of its T_0008_* protocol files. The
+# IoLife appliance list does not return an enterpriseCode field, so this is the
+# fallback for it.
 _IOLIFE_MANUFACTURER_CODE = "0008"
 
 
@@ -1165,7 +1168,10 @@ class ToshibaIOLife(MideaAirCloud):
                 "sn": sn,
                 "sn8": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
                 "model_number": model_number,
-                "manufacturer_code": _IOLIFE_MANUFACTURER_CODE,
+                "manufacturer_code": appliance.get(
+                    "enterpriseCode",
+                    _IOLIFE_MANUFACTURER_CODE,
+                ),
                 "model": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
                 "online": appliance.get("onlineStatus") == "1",
             }

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -6,13 +6,17 @@ import logging
 import re
 import time
 from asyncio import Lock
+from collections.abc import Mapping
 from datetime import UTC, datetime
+from hashlib import md5
 from http import HTTPStatus
 from secrets import token_hex
 from typing import Any, cast
 
 import aiofiles
 from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
 
 from midealocal.exceptions import ElementMissing
 
@@ -69,6 +73,12 @@ SUPPORTED_CLOUDS: dict[str, Any] = {
         "app_id": "1005",
         "app_key": "434a209a5ce141c3b726de067835d7f0",
         "api_url": "https://mapp.appsmb.com",  # codespell:ignore
+    },
+    "Toshiba Iolife": {
+        "class_name": "ToshibaIOLife",
+        "app_id": "1203",
+        "app_key": "09c4d09f0da1513bb62dc7b6b0af9c11",
+        "api_url": "https://app.iolife.toshiba-lifestyle.com",  # codespell:ignore
     },
 }
 
@@ -1000,6 +1010,99 @@ class MideaAirCloud(MideaCloud):
                 appliances[int(appliance["id"])] = device_info
             return appliances
         return None
+
+
+class ToshibaIOLife(MideaAirCloud):
+    """Toshiba IOLife cloud."""
+
+    def _decrypt_sn(self, encrypted_sn: str) -> str:
+        """Decrypt SN blob from home/page/list/info.
+
+        The server encrypts the SN string with AES-128-ECB using a session
+        data_key derived from the accessToken:
+          aes_key  = MD5(app_key)[:16]
+          data_key = AES_ECB_decrypt(bytes.fromhex(accessToken), aes_key)
+          sn       = AES_ECB_decrypt(bytes.fromhex(encrypted_sn), data_key)
+        """
+        if not self._access_token or not encrypted_sn:
+            return ""
+        try:
+            aes_key = (
+                md5(
+                    self._app_key.encode(),
+                    usedforsecurity=False,
+                )
+                .hexdigest()[:16]
+                .encode()
+            )
+            token_bytes = bytes.fromhex(self._access_token)
+            data_key = bytes(
+                unpad(AES.new(aes_key, AES.MODE_ECB).decrypt(token_bytes), 16),
+            )
+            sn_bytes = bytes.fromhex(encrypted_sn)
+            plain = unpad(AES.new(data_key[:16], AES.MODE_ECB).decrypt(sn_bytes), 16)
+            return plain.decode()
+        except Exception:  # noqa: BLE001
+            return ""
+
+    async def list_appliance_types(
+        self,
+    ) -> dict[str, Any] | None:
+        """List Toshiba IOLife device types."""
+        data = self._make_general_data()
+        data.update({"applianceType": "0xFF"})
+        if response := await self._api_request(
+            endpoint="/v1/appliance/type/list/get",
+            data=data,
+        ):
+            return response
+        return None
+
+    async def list_appliances(
+        self,
+        home_id: str | None = None,  # noqa: ARG002
+    ) -> dict[int, dict[str, Any]] | None:
+        """Get Toshiba IOLife devices."""
+        data = self._make_general_data()
+        data["appVersion"] = "3.4.0"
+        # home/page/list/info returns result as a bare list, not {list: [...]}
+        page_list: Any = await self._api_request(
+            endpoint="/v1/appliance/user/home/page/list/info",
+            data=data,
+        )
+        if not isinstance(page_list, list):
+            return None
+
+        appliances: dict[int, dict[str, Any]] = {}
+        for appliance in page_list:
+            if not isinstance(appliance, Mapping):
+                continue
+            # Skip virtual/batch devices
+            if appliance.get("type") == "0x_BATCH_AC":
+                continue
+            if appliance.get("id") == "virtual_ag_0xAC":
+                continue
+            try:
+                device_id = int(appliance["id"])
+                model_number = int(appliance.get("modelNumber", 0))
+                device_type = int(appliance["type"], 16)
+            except (ValueError, KeyError, TypeError):
+                _LOGGER.debug("Skipping malformed appliance entry: %s", appliance)
+                continue
+            sn = self._decrypt_sn(appliance.get("sn", ""))
+            appliances[device_id] = {
+                "name": appliance.get("name"),
+                "type": device_type,
+                "sn": sn,
+                "sn8": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "model_number": model_number,
+                # All Toshiba IoLife devices carry manufacturer code 0x0008.
+                "manufacturer_code": "0008",
+                "model": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "online": appliance.get("onlineStatus") == "1",
+            }
+
+        return appliances if appliances else None
 
 
 def get_midea_cloud(

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -1045,19 +1045,6 @@ class ToshibaIOLife(MideaAirCloud):
         except Exception:  # noqa: BLE001
             return ""
 
-    async def list_appliance_types(
-        self,
-    ) -> dict[str, Any] | None:
-        """List Toshiba IOLife device types."""
-        data = self._make_general_data()
-        data.update({"applianceType": "0xFF"})
-        if response := await self._api_request(
-            endpoint="/v1/appliance/type/list/get",
-            data=data,
-        ):
-            return response
-        return None
-
     async def list_appliances(
         self,
         home_id: str | None = None,  # noqa: ARG002

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -79,7 +79,7 @@ SUPPORTED_CLOUDS: dict[str, Any] = {
         "class_name": "ToshibaIOLife",
         "app_id": "1203",
         "app_key": "09c4d09f0da1513bb62dc7b6b0af9c11",
-        "api_url": "https://app.iolife.toshiba-lifestyle.com",  # codespell:ignore
+        "api_url": "https://app.iolife.toshiba-lifestyle.com",
     },
 }
 

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -1154,25 +1154,29 @@ class ToshibaIOLife(MideaAirCloud):
                 or appliance.get("id") == "virtual_ag_0xAC"
             ):
                 continue
-            model_number = int(appliance.get("modelNumber", 0))
             try:
                 device_id = int(appliance["id"])
                 device_type = int(appliance["type"], 16)
             except (ValueError, KeyError, TypeError):
                 _LOGGER.debug("Skipping malformed appliance entry: %s", appliance)
                 continue
+            try:
+                model_number = int(appliance.get("modelNumber", 0))
+            except (ValueError, TypeError):
+                model_number = 0
             sn = self._decrypt_sn(appliance.get("sn", ""))
+            sn8 = sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else ""
             appliances[device_id] = {
                 "name": appliance.get("name"),
                 "type": device_type,
                 "sn": sn,
-                "sn8": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "sn8": sn8,
                 "model_number": model_number,
                 "manufacturer_code": appliance.get(
                     "enterpriseCode",
                     _IOLIFE_MANUFACTURER_CODE,
                 ),
-                "model": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "model": sn8,
                 "online": appliance.get("onlineStatus") == "1",
             }
 

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -1121,19 +1121,6 @@ class ToshibaIOLife(MideaAirCloud):
         except Exception:  # noqa: BLE001
             return ""
 
-    async def list_appliance_types(
-        self,
-    ) -> dict[str, Any] | None:
-        """List Toshiba IOLife device types."""
-        data = self._make_general_data()
-        data.update({"applianceType": "0xFF"})
-        if response := await self._api_request(
-            endpoint="/v1/appliance/type/list/get",
-            data=data,
-        ):
-            return response
-        return None
-
     async def list_appliances(
         self,
         home_id: str | None = None,  # noqa: ARG002

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -6,7 +6,9 @@ import logging
 import re
 import time
 from asyncio import Lock
+from collections.abc import Mapping
 from datetime import UTC, datetime
+from hashlib import md5
 from http import HTTPStatus
 from pathlib import PurePosixPath, PureWindowsPath
 from secrets import token_hex
@@ -14,6 +16,8 @@ from typing import Any, cast
 
 import aiofiles
 from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
 
 from midealocal.exceptions import ElementMissing
 
@@ -70,6 +74,12 @@ SUPPORTED_CLOUDS: dict[str, Any] = {
         "app_id": "1005",
         "app_key": "434a209a5ce141c3b726de067835d7f0",
         "api_url": "https://mapp.appsmb.com",  # codespell:ignore
+    },
+    "Toshiba Iolife": {
+        "class_name": "ToshibaIOLife",
+        "app_id": "1203",
+        "app_key": "09c4d09f0da1513bb62dc7b6b0af9c11",
+        "api_url": "https://app.iolife.toshiba-lifestyle.com",  # codespell:ignore
     },
 }
 
@@ -1076,6 +1086,99 @@ class MideaAirCloud(MideaCloud):
                     async with aiofiles.open(fnm, "w") as fp:
                         await fp.write(stream)
         return str(fnm) if fnm else None
+
+
+class ToshibaIOLife(MideaAirCloud):
+    """Toshiba IOLife cloud."""
+
+    def _decrypt_sn(self, encrypted_sn: str) -> str:
+        """Decrypt SN blob from home/page/list/info.
+
+        The server encrypts the SN string with AES-128-ECB using a session
+        data_key derived from the accessToken:
+          aes_key  = MD5(app_key)[:16]
+          data_key = AES_ECB_decrypt(bytes.fromhex(accessToken), aes_key)
+          sn       = AES_ECB_decrypt(bytes.fromhex(encrypted_sn), data_key)
+        """
+        if not self._access_token or not encrypted_sn:
+            return ""
+        try:
+            aes_key = (
+                md5(
+                    self._app_key.encode(),
+                    usedforsecurity=False,
+                )
+                .hexdigest()[:16]
+                .encode()
+            )
+            token_bytes = bytes.fromhex(self._access_token)
+            data_key = bytes(
+                unpad(AES.new(aes_key, AES.MODE_ECB).decrypt(token_bytes), 16),
+            )
+            sn_bytes = bytes.fromhex(encrypted_sn)
+            plain = unpad(AES.new(data_key[:16], AES.MODE_ECB).decrypt(sn_bytes), 16)
+            return plain.decode()
+        except Exception:  # noqa: BLE001
+            return ""
+
+    async def list_appliance_types(
+        self,
+    ) -> dict[str, Any] | None:
+        """List Toshiba IOLife device types."""
+        data = self._make_general_data()
+        data.update({"applianceType": "0xFF"})
+        if response := await self._api_request(
+            endpoint="/v1/appliance/type/list/get",
+            data=data,
+        ):
+            return response
+        return None
+
+    async def list_appliances(
+        self,
+        home_id: str | None = None,  # noqa: ARG002
+    ) -> dict[int, dict[str, Any]] | None:
+        """Get Toshiba IOLife devices."""
+        data = self._make_general_data()
+        data["appVersion"] = "3.4.0"
+        # home/page/list/info returns result as a bare list, not {list: [...]}
+        page_list: Any = await self._api_request(
+            endpoint="/v1/appliance/user/home/page/list/info",
+            data=data,
+        )
+        if not isinstance(page_list, list):
+            return None
+
+        appliances: dict[int, dict[str, Any]] = {}
+        for appliance in page_list:
+            if not isinstance(appliance, Mapping):
+                continue
+            # Skip virtual/batch devices
+            if appliance.get("type") == "0x_BATCH_AC":
+                continue
+            if appliance.get("id") == "virtual_ag_0xAC":
+                continue
+            try:
+                device_id = int(appliance["id"])
+                model_number = int(appliance.get("modelNumber", 0))
+                device_type = int(appliance["type"], 16)
+            except (ValueError, KeyError, TypeError):
+                _LOGGER.debug("Skipping malformed appliance entry: %s", appliance)
+                continue
+            sn = self._decrypt_sn(appliance.get("sn", ""))
+            appliances[device_id] = {
+                "name": appliance.get("name"),
+                "type": device_type,
+                "sn": sn,
+                "sn8": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "model_number": model_number,
+                # All Toshiba IoLife devices carry manufacturer code 0x0008.
+                "manufacturer_code": "0008",
+                "model": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
+                "online": appliance.get("onlineStatus") == "1",
+            }
+
+        return appliances if appliances else None
 
 
 def get_midea_cloud(

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -1088,6 +1088,11 @@ class MideaAirCloud(MideaCloud):
         return str(fnm) if fnm else None
 
 
+_IOLIFE_APP_VERSION = "3.4.0"
+# All Toshiba IoLife devices carry manufacturer code 0x0008.
+_IOLIFE_MANUFACTURER_CODE = "0008"
+
+
 class ToshibaIOLife(MideaAirCloud):
     """Toshiba IOLife cloud."""
 
@@ -1124,30 +1129,31 @@ class ToshibaIOLife(MideaAirCloud):
     async def list_appliances(
         self,
         home_id: str | None = None,  # noqa: ARG002
-    ) -> dict[int, dict[str, Any]] | None:
+    ) -> dict[int, dict[str, Any]]:
         """Get Toshiba IOLife devices."""
         data = self._make_general_data()
-        data["appVersion"] = "3.4.0"
+        data["appVersion"] = _IOLIFE_APP_VERSION
         # home/page/list/info returns result as a bare list, not {list: [...]}
         page_list: Any = await self._api_request(
             endpoint="/v1/appliance/user/home/page/list/info",
             data=data,
         )
         if not isinstance(page_list, list):
-            return None
+            return {}
 
         appliances: dict[int, dict[str, Any]] = {}
         for appliance in page_list:
             if not isinstance(appliance, Mapping):
                 continue
             # Skip virtual/batch devices
-            if appliance.get("type") == "0x_BATCH_AC":
+            if (
+                appliance.get("type") == "0x_BATCH_AC"
+                or appliance.get("id") == "virtual_ag_0xAC"
+            ):
                 continue
-            if appliance.get("id") == "virtual_ag_0xAC":
-                continue
+            model_number = int(appliance.get("modelNumber", 0))
             try:
                 device_id = int(appliance["id"])
-                model_number = int(appliance.get("modelNumber", 0))
                 device_type = int(appliance["type"], 16)
             except (ValueError, KeyError, TypeError):
                 _LOGGER.debug("Skipping malformed appliance entry: %s", appliance)
@@ -1159,13 +1165,12 @@ class ToshibaIOLife(MideaAirCloud):
                 "sn": sn,
                 "sn8": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
                 "model_number": model_number,
-                # All Toshiba IoLife devices carry manufacturer code 0x0008.
-                "manufacturer_code": "0008",
+                "manufacturer_code": _IOLIFE_MANUFACTURER_CODE,
                 "model": sn[9:17] if len(sn) > SN8_MIN_SERIAL_LENGTH else "",
                 "online": appliance.get("onlineStatus") == "1",
             }
 
-        return appliances if appliances else None
+        return appliances
 
 
 def get_midea_cloud(

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -80,6 +80,11 @@ SUPPORTED_CLOUDS: dict[str, Any] = {
         "app_id": "1203",
         "app_key": "09c4d09f0da1513bb62dc7b6b0af9c11",
         "api_url": "https://app.iolife.toshiba-lifestyle.com",
+        "app_version": "3.4.0",
+        # The API does not return an enterpriseCode, so this is the fallback.
+        # 0x0008 is Toshiba's code: the app ships it as APP_ENTERPRISE
+        # and it prefixes every T_0008_* protocol file.
+        "manufacturer_code": "0008",
     },
 }
 
@@ -1088,16 +1093,26 @@ class MideaAirCloud(MideaCloud):
         return str(fnm) if fnm else None
 
 
-_IOLIFE_APP_VERSION = "3.4.0"
-# All Toshiba IoLife devices carry manufacturer code 0x0008 -- the same value the
-# app ships as APP_ENTERPRISE and the prefix of its T_0008_* protocol files. The
-# IoLife appliance list does not return an enterpriseCode field, so this is the
-# fallback for it.
-_IOLIFE_MANUFACTURER_CODE = "0008"
-
-
 class ToshibaIOLife(MideaAirCloud):
     """Toshiba IOLife cloud."""
+
+    def __init__(
+        self,
+        cloud_name: str,
+        session: ClientSession,
+        account: str,
+        password: str,
+    ) -> None:
+        """Initialize Toshiba IOLife cloud."""
+        super().__init__(
+            cloud_name=cloud_name,
+            session=session,
+            account=account,
+            password=password,
+        )
+        cloud_data = cast("dict[str, Any]", SUPPORTED_CLOUDS[cloud_name])
+        self._app_version: str = cloud_data["app_version"]
+        self._manufacturer_code: str = cloud_data["manufacturer_code"]
 
     def _decrypt_sn(self, encrypted_sn: str) -> str:
         """Decrypt SN blob from home/page/list/info.
@@ -1126,7 +1141,8 @@ class ToshibaIOLife(MideaAirCloud):
             sn_bytes = bytes.fromhex(encrypted_sn)
             plain = unpad(AES.new(data_key[:16], AES.MODE_ECB).decrypt(sn_bytes), 16)
             return plain.decode()
-        except Exception:  # noqa: BLE001
+        except ValueError:
+            _LOGGER.debug("Failed to decrypt appliance SN")
             return ""
 
     async def list_appliances(
@@ -1135,7 +1151,7 @@ class ToshibaIOLife(MideaAirCloud):
     ) -> dict[int, dict[str, Any]]:
         """Get Toshiba IOLife devices."""
         data = self._make_general_data()
-        data["appVersion"] = _IOLIFE_APP_VERSION
+        data["appVersion"] = self._app_version
         # home/page/list/info returns result as a bare list, not {list: [...]}
         page_list: Any = await self._api_request(
             endpoint="/v1/appliance/user/home/page/list/info",
@@ -1174,7 +1190,7 @@ class ToshibaIOLife(MideaAirCloud):
                 "model_number": model_number,
                 "manufacturer_code": appliance.get(
                     "enterpriseCode",
-                    _IOLIFE_MANUFACTURER_CODE,
+                    self._manufacturer_code,
                 ),
                 "model": sn8,
                 "online": appliance.get("onlineStatus") == "1",

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -15,6 +15,7 @@ from midealocal.cloud import (
     MideaAirCloud,
     MideaCloud,
     SmartHomeCloud,
+    ToshibaIOLife,
     _mask_token,
     get_default_cloud,
     get_midea_cloud,
@@ -83,7 +84,7 @@ class CloudTest(IsolatedAsyncioTestCase):
     async def test_get_cloud_servers(self) -> None:
         """Test get cloud servers."""
         servers = await MideaCloud.get_cloud_servers()
-        assert len(servers.items()) == 5
+        assert len(servers.items()) == 6
 
     async def test_get_preset_account_cloud(self) -> None:
         """Test get preset cloud account."""
@@ -790,3 +791,135 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         with pytest.raises(NotImplementedError), TemporaryDirectory() as tmpdir:
             await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
+
+
+class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
+    """ToshibaIOLife cloud test case."""
+
+    responses: ClassVar[dict[str, bytes]] = {}
+
+    APP_KEY = "00000000000000000000000000000000"
+    ACCESS_TOKEN = "e4ddcc22d5ccc270e3b1c876df7c9a8d0a31b22810d0e532c2dd921bb9e0389f"
+    ENCRYPTED_SN = (
+        "e1f17526c18d049e4862e19f5d6cd269"
+        "df9b09edd41d4b2627b35dbb2d47b963"
+        "a433df71998b41d4dc354e9bdf78902a"
+    )
+    EXPECTED_SN = "0008AC0000000000000000000000BEEF"
+
+    def setUp(self) -> None:
+        """Load shared response fixtures."""
+        file_path = Path(__file__)
+        for file in Path.iterdir(Path(file_path.parent, "responses")):
+            fp = Path(file)
+            with fp.open(encoding="utf-8") as f:
+                self.responses[fp.name] = bytes(f.read(), encoding="utf-8")
+
+    def _make_cloud(self, session: Mock) -> ToshibaIOLife:
+        cloud = get_midea_cloud(
+            "Toshiba Iolife",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert isinstance(cloud, ToshibaIOLife)
+        cloud._app_key = self.APP_KEY
+        return cloud
+
+    def test_decrypt_sn_known_vector(self) -> None:
+        """_decrypt_sn returns correct SN for a synthetic valid vector."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == self.EXPECTED_SN
+
+    def test_decrypt_sn_no_token(self) -> None:
+        """_decrypt_sn returns '' when no access token is set."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = None
+        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == ""
+
+    def test_decrypt_sn_empty_sn(self) -> None:
+        """_decrypt_sn returns '' for an empty encrypted_sn."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn("") == ""
+
+    def test_decrypt_sn_bad_ciphertext(self) -> None:
+        """Corrupt ciphertext (unpadding fails) returns '' instead of raising."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn("deadbeef" * 4) == ""
+
+    async def test_list_appliances_success(self) -> None:
+        """list_appliances decrypts SN inline and skips virtual devices."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["mideaaircloud_login_id.json"],
+                self.responses["mideaaircloud_login.json"],
+                self.responses["toshibaiolife_list_appliances.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = self._make_cloud(session)
+        assert await cloud.login()
+        cloud._access_token = self.ACCESS_TOKEN
+
+        appliances = await cloud.list_appliances(None)
+        assert appliances is not None
+        assert len(appliances) == 1
+
+        dev = appliances[12345678]
+        assert dev["name"] == "Living Room AC"
+        assert dev["type"] == 0xAC
+        assert dev["sn"] == self.EXPECTED_SN
+        assert dev["sn8"] == "00000000"
+        assert dev["model_number"] == 10
+        assert dev["manufacturer_code"] == "0008"
+        assert dev["model"] == "00000000"
+        assert dev["online"] is True
+
+    async def test_list_appliances_api_failure(self) -> None:
+        """list_appliances returns None when the API returns an error."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            return_value=self.responses["mideaaircloud_invalid_response.json"],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = self._make_cloud(session)
+        cloud._access_token = self.ACCESS_TOKEN
+        assert await cloud.list_appliances(None) is None
+
+    async def test_list_appliances_non_list_response(self) -> None:
+        """list_appliances returns None when the API returns a non-list."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(return_value={"result": []}),
+        ):
+            assert await cloud.list_appliances(None) is None
+
+    async def test_list_appliances_skips_non_mapping_entries(self) -> None:
+        """list_appliances silently skips non-mapping entries in the list."""
+        entry = {
+            "id": "12345678",
+            "type": "0xAC",
+            "name": "Living Room AC",
+            "modelNumber": 10,
+            "onlineStatus": "1",
+            "sn": self.ENCRYPTED_SN,
+        }
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(return_value=["not-a-mapping", entry]),
+        ):
+            appliances = await cloud.list_appliances(None)
+        assert appliances is not None
+        assert len(appliances) == 1

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1054,6 +1054,33 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         assert request.await_args is not None
         assert request.await_args.kwargs["data"]["appVersion"] == "3.4.0"
 
+    async def test_list_appliances_skips_malformed_entries(self) -> None:
+        """Entries with an unusable id or type are skipped, not fatal."""
+        cloud = self.make_cloud(Mock())
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
+        good = {
+            "id": "12345678",
+            "type": "0xAC",
+            "name": "Living Room AC",
+            "modelNumber": "10",
+            "onlineStatus": "1",
+        }
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(
+                return_value=[
+                    {"id": "not-a-number", "type": "0xAC"},
+                    {"id": "1", "type": "not-hex"},
+                    {"type": "0xAC"},
+                    {"id": "2", "type": None},
+                    good,
+                ],
+            ),
+        ):
+            appliances = await cloud.list_appliances(None)
+        assert list(appliances) == [12345678]
+
     async def test_list_appliances_non_numeric_model_number(self) -> None:
         """A non-numeric modelNumber falls back to 0 rather than raising."""
         cloud = self.make_cloud(Mock())

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -15,6 +15,7 @@ from midealocal.cloud import (
     MideaAirCloud,
     MideaCloud,
     SmartHomeCloud,
+    ToshibaIOLife,
     _mask_token,
     _redact_data,
     get_default_cloud,
@@ -147,7 +148,7 @@ class CloudTest(IsolatedAsyncioTestCase):
     async def test_get_cloud_servers(self) -> None:
         """Test get cloud servers."""
         servers = await MideaCloud.get_cloud_servers()
-        assert len(servers.items()) == 5
+        assert len(servers.items()) == 6
 
     async def test_get_preset_account_cloud(self) -> None:
         """Test get preset cloud account."""
@@ -939,3 +940,148 @@ class CloudTest(IsolatedAsyncioTestCase):
 
         device = await cloud.get_device_info(99)
         assert device is None
+
+    async def test_mideaaircloud_download_lua(self) -> None:
+        """Test MideaAirCloud download_lua."""
+        session = Mock()
+        cloud = get_midea_cloud(
+            "Midea Air",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+        with pytest.raises(NotImplementedError), TemporaryDirectory() as tmpdir:
+            await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
+
+
+class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
+    """ToshibaIOLife cloud test case."""
+
+    responses: ClassVar[dict[str, bytes]] = {}
+
+    APP_KEY = "00000000000000000000000000000000"
+    ACCESS_TOKEN = "e4ddcc22d5ccc270e3b1c876df7c9a8d0a31b22810d0e532c2dd921bb9e0389f"
+    ENCRYPTED_SN = (
+        "e1f17526c18d049e4862e19f5d6cd269"
+        "df9b09edd41d4b2627b35dbb2d47b963"
+        "a433df71998b41d4dc354e9bdf78902a"
+    )
+    EXPECTED_SN = "0008AC0000000000000000000000BEEF"
+
+    def setUp(self) -> None:
+        """Load shared response fixtures."""
+        file_path = Path(__file__)
+        for file in Path.iterdir(Path(file_path.parent, "responses")):
+            fp = Path(file)
+            with fp.open(encoding="utf-8") as f:
+                self.responses[fp.name] = bytes(f.read(), encoding="utf-8")
+
+    def _make_cloud(self, session: Mock) -> ToshibaIOLife:
+        cloud = get_midea_cloud(
+            "Toshiba Iolife",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert isinstance(cloud, ToshibaIOLife)
+        cloud._app_key = self.APP_KEY
+        return cloud
+
+    def test_decrypt_sn_known_vector(self) -> None:
+        """_decrypt_sn returns correct SN for a synthetic valid vector."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == self.EXPECTED_SN
+
+    def test_decrypt_sn_no_token(self) -> None:
+        """_decrypt_sn returns '' when no access token is set."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = None
+        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == ""
+
+    def test_decrypt_sn_empty_sn(self) -> None:
+        """_decrypt_sn returns '' for an empty encrypted_sn."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn("") == ""
+
+    def test_decrypt_sn_bad_ciphertext(self) -> None:
+        """Corrupt ciphertext (unpadding fails) returns '' instead of raising."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        assert cloud._decrypt_sn("deadbeef" * 4) == ""
+
+    async def test_list_appliances_success(self) -> None:
+        """list_appliances decrypts SN inline and skips virtual devices."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["mideaaircloud_login_id.json"],
+                self.responses["mideaaircloud_login.json"],
+                self.responses["toshibaiolife_list_appliances.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = self._make_cloud(session)
+        assert await cloud.login()
+        cloud._access_token = self.ACCESS_TOKEN
+
+        appliances = await cloud.list_appliances(None)
+        assert appliances is not None
+        assert len(appliances) == 1
+
+        dev = appliances[12345678]
+        assert dev["name"] == "Living Room AC"
+        assert dev["type"] == 0xAC
+        assert dev["sn"] == self.EXPECTED_SN
+        assert dev["sn8"] == "00000000"
+        assert dev["model_number"] == 10
+        assert dev["manufacturer_code"] == "0008"
+        assert dev["model"] == "00000000"
+        assert dev["online"] is True
+
+    async def test_list_appliances_api_failure(self) -> None:
+        """list_appliances returns None when the API returns an error."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            return_value=self.responses["mideaaircloud_invalid_response.json"],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = self._make_cloud(session)
+        cloud._access_token = self.ACCESS_TOKEN
+        assert await cloud.list_appliances(None) is None
+
+    async def test_list_appliances_non_list_response(self) -> None:
+        """list_appliances returns None when the API returns a non-list."""
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(return_value={"result": []}),
+        ):
+            assert await cloud.list_appliances(None) is None
+
+    async def test_list_appliances_skips_non_mapping_entries(self) -> None:
+        """list_appliances silently skips non-mapping entries in the list."""
+        entry = {
+            "id": "12345678",
+            "type": "0xAC",
+            "name": "Living Room AC",
+            "modelNumber": 10,
+            "onlineStatus": "1",
+            "sn": self.ENCRYPTED_SN,
+        }
+        cloud = self._make_cloud(Mock())
+        cloud._access_token = self.ACCESS_TOKEN
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(return_value=["not-a-mapping", entry]),
+        ):
+            appliances = await cloud.list_appliances(None)
+        assert appliances is not None
+        assert len(appliances) == 1

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -955,19 +955,6 @@ class CloudTest(IsolatedAsyncioTestCase):
         device = await cloud.get_device_info(99)
         assert device is None
 
-    async def test_mideaaircloud_download_lua(self) -> None:
-        """Test MideaAirCloud download_lua."""
-        session = Mock()
-        cloud = get_midea_cloud(
-            "Midea Air",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert cloud is not None
-        with pytest.raises(NotImplementedError), TemporaryDirectory() as tmpdir:
-            await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
-
 
 @pytest.fixture(name="make_toshiba_cloud")
 def make_toshiba_cloud_fixture() -> Callable[[Mock], ToshibaIOLife]:
@@ -997,6 +984,8 @@ class TestToshibaDecryptSn:
             (_TOSHIBA_ENCRYPTED_SN, None, ""),
             ("", _TOSHIBA_ACCESS_TOKEN, ""),
             ("deadbeef" * 4, _TOSHIBA_ACCESS_TOKEN, ""),
+            ("nothexatall", _TOSHIBA_ACCESS_TOKEN, ""),
+            (_TOSHIBA_ENCRYPTED_SN, "nothexatall", ""),
         ],
     )
     def test_decrypt_sn(
@@ -1054,6 +1043,16 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         assert dev["manufacturer_code"] == "0008"
         assert dev["model"] == "00000000"
         assert dev["online"] is True
+
+    async def test_list_appliances_uses_cloud_app_version(self) -> None:
+        """AppVersion comes from the SUPPORTED_CLOUDS entry."""
+        cloud = self.make_cloud(Mock())
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
+        request = AsyncMock(return_value=[])
+        with patch.object(cloud, "_api_request", new=request):
+            await cloud.list_appliances(None)
+        assert request.await_args is not None
+        assert request.await_args.kwargs["data"]["appVersion"] == "3.4.0"
 
     async def test_list_appliances_non_numeric_model_number(self) -> None:
         """A non-numeric modelNumber falls back to 0 rather than raising."""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -25,20 +25,33 @@ from midealocal.cloud import (
 from midealocal.exceptions import ElementMissing
 
 
+def _load_responses() -> dict[str, bytes]:
+    """Load all JSON fixtures from tests/responses/ once."""
+    return {
+        fp.name: fp.read_bytes()
+        for fp in (Path(__file__).parent / "responses").iterdir()
+        if fp.is_file()
+    }
+
+
+_RESPONSES: dict[str, bytes] = _load_responses()
+
+_TOSHIBA_APP_KEY = "00000000000000000000000000000000"
+_TOSHIBA_ACCESS_TOKEN = (
+    "e4ddcc22d5ccc270e3b1c876df7c9a8d0a31b22810d0e532c2dd921bb9e0389f"
+)
+_TOSHIBA_ENCRYPTED_SN = (
+    "e1f17526c18d049e4862e19f5d6cd269"
+    "df9b09edd41d4b2627b35dbb2d47b963"
+    "a433df71998b41d4dc354e9bdf78902a"
+)
+_TOSHIBA_EXPECTED_SN = "0008AC0000000000000000000000BEEF"
+
+
 class CloudTest(IsolatedAsyncioTestCase):
     """Cloud test case."""
 
-    responses: ClassVar[dict[str, bytes]] = {}
-
-    def setUp(self) -> None:
-        """Set tests up."""
-        file_path = Path(__file__)
-        for file in Path.iterdir(Path(file_path.parent, "responses")):
-            file_path = Path(file)
-            with file_path.open(
-                encoding="utf-8",
-            ) as f:
-                self.responses[file_path.name] = bytes(f.read(), encoding="utf-8")
+    responses: ClassVar[dict[str, bytes]] = _RESPONSES
 
     def test_get_midea_cloud(self) -> None:
         """Test get midea cloud."""
@@ -955,62 +968,45 @@ class CloudTest(IsolatedAsyncioTestCase):
             await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
 
 
-class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
-    """ToshibaIOLife cloud test case."""
-
-    responses: ClassVar[dict[str, bytes]] = {}
-
-    APP_KEY = "00000000000000000000000000000000"
-    ACCESS_TOKEN = "e4ddcc22d5ccc270e3b1c876df7c9a8d0a31b22810d0e532c2dd921bb9e0389f"
-    ENCRYPTED_SN = (
-        "e1f17526c18d049e4862e19f5d6cd269"
-        "df9b09edd41d4b2627b35dbb2d47b963"
-        "a433df71998b41d4dc354e9bdf78902a"
+def _make_toshiba_cloud(session: Mock) -> ToshibaIOLife:
+    """Create a ToshibaIOLife instance with a synthetic app key."""
+    cloud = get_midea_cloud(
+        "Toshiba Iolife",
+        session=session,
+        account="account",
+        password="password",
     )
-    EXPECTED_SN = "0008AC0000000000000000000000BEEF"
+    assert isinstance(cloud, ToshibaIOLife)
+    cloud._app_key = _TOSHIBA_APP_KEY
+    return cloud
 
-    def setUp(self) -> None:
-        """Load shared response fixtures."""
-        file_path = Path(__file__)
-        for file in Path.iterdir(Path(file_path.parent, "responses")):
-            fp = Path(file)
-            with fp.open(encoding="utf-8") as f:
-                self.responses[fp.name] = bytes(f.read(), encoding="utf-8")
 
-    def _make_cloud(self, session: Mock) -> ToshibaIOLife:
-        cloud = get_midea_cloud(
-            "Toshiba Iolife",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert isinstance(cloud, ToshibaIOLife)
-        cloud._app_key = self.APP_KEY
-        return cloud
+class TestToshibaDecryptSn:
+    """Parametrized unit tests for ToshibaIOLife._decrypt_sn."""
 
-    def test_decrypt_sn_known_vector(self) -> None:
-        """_decrypt_sn returns correct SN for a synthetic valid vector."""
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = self.ACCESS_TOKEN
-        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == self.EXPECTED_SN
+    @pytest.mark.parametrize(
+        ("encrypted_sn", "access_token", "expected"),
+        [
+            (_TOSHIBA_ENCRYPTED_SN, _TOSHIBA_ACCESS_TOKEN, _TOSHIBA_EXPECTED_SN),
+            (_TOSHIBA_ENCRYPTED_SN, None, ""),
+            ("", _TOSHIBA_ACCESS_TOKEN, ""),
+            ("deadbeef" * 4, _TOSHIBA_ACCESS_TOKEN, ""),
+        ],
+    )
+    def test_decrypt_sn(
+        self,
+        encrypted_sn: str,
+        access_token: str | None,
+        expected: str,
+    ) -> None:
+        """_decrypt_sn returns correct SN or '' on error/empty input."""
+        cloud = _make_toshiba_cloud(Mock())
+        cloud._access_token = access_token
+        assert cloud._decrypt_sn(encrypted_sn) == expected
 
-    def test_decrypt_sn_no_token(self) -> None:
-        """_decrypt_sn returns '' when no access token is set."""
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = None
-        assert cloud._decrypt_sn(self.ENCRYPTED_SN) == ""
 
-    def test_decrypt_sn_empty_sn(self) -> None:
-        """_decrypt_sn returns '' for an empty encrypted_sn."""
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = self.ACCESS_TOKEN
-        assert cloud._decrypt_sn("") == ""
-
-    def test_decrypt_sn_bad_ciphertext(self) -> None:
-        """Corrupt ciphertext (unpadding fails) returns '' instead of raising."""
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = self.ACCESS_TOKEN
-        assert cloud._decrypt_sn("deadbeef" * 4) == ""
+class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
+    """ToshibaIOLife cloud async tests."""
 
     async def test_list_appliances_success(self) -> None:
         """list_appliances decrypts SN inline and skips virtual devices."""
@@ -1018,24 +1014,23 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         response = Mock()
         response.read = AsyncMock(
             side_effect=[
-                self.responses["mideaaircloud_login_id.json"],
-                self.responses["mideaaircloud_login.json"],
-                self.responses["toshibaiolife_list_appliances.json"],
+                _RESPONSES["mideaaircloud_login_id.json"],
+                _RESPONSES["mideaaircloud_login.json"],
+                _RESPONSES["toshibaiolife_list_appliances.json"],
             ],
         )
         session.request = AsyncMock(return_value=response)
-        cloud = self._make_cloud(session)
+        cloud = _make_toshiba_cloud(session)
         assert await cloud.login()
-        cloud._access_token = self.ACCESS_TOKEN
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
 
         appliances = await cloud.list_appliances(None)
-        assert appliances is not None
         assert len(appliances) == 1
 
         dev = appliances[12345678]
         assert dev["name"] == "Living Room AC"
         assert dev["type"] == 0xAC
-        assert dev["sn"] == self.EXPECTED_SN
+        assert dev["sn"] == _TOSHIBA_EXPECTED_SN
         assert dev["sn8"] == "00000000"
         assert dev["model_number"] == 10
         assert dev["manufacturer_code"] == "0008"
@@ -1043,27 +1038,27 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         assert dev["online"] is True
 
     async def test_list_appliances_api_failure(self) -> None:
-        """list_appliances returns None when the API returns an error."""
+        """list_appliances returns empty dict when the API returns an error."""
         session = Mock()
         response = Mock()
         response.read = AsyncMock(
-            return_value=self.responses["mideaaircloud_invalid_response.json"],
+            return_value=_RESPONSES["mideaaircloud_invalid_response.json"],
         )
         session.request = AsyncMock(return_value=response)
-        cloud = self._make_cloud(session)
-        cloud._access_token = self.ACCESS_TOKEN
-        assert await cloud.list_appliances(None) is None
+        cloud = _make_toshiba_cloud(session)
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
+        assert await cloud.list_appliances(None) == {}
 
     async def test_list_appliances_non_list_response(self) -> None:
-        """list_appliances returns None when the API returns a non-list."""
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = self.ACCESS_TOKEN
+        """list_appliances returns empty dict when the API returns a non-list."""
+        cloud = _make_toshiba_cloud(Mock())
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         with patch.object(
             cloud,
             "_api_request",
             new=AsyncMock(return_value={"result": []}),
         ):
-            assert await cloud.list_appliances(None) is None
+            assert await cloud.list_appliances(None) == {}
 
     async def test_list_appliances_skips_non_mapping_entries(self) -> None:
         """list_appliances silently skips non-mapping entries in the list."""
@@ -1073,15 +1068,14 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
             "name": "Living Room AC",
             "modelNumber": 10,
             "onlineStatus": "1",
-            "sn": self.ENCRYPTED_SN,
+            "sn": _TOSHIBA_ENCRYPTED_SN,
         }
-        cloud = self._make_cloud(Mock())
-        cloud._access_token = self.ACCESS_TOKEN
+        cloud = _make_toshiba_cloud(Mock())
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         with patch.object(
             cloud,
             "_api_request",
             new=AsyncMock(return_value=["not-a-mapping", entry]),
         ):
             appliances = await cloud.list_appliances(None)
-        assert appliances is not None
         assert len(appliances) == 1

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1037,6 +1037,28 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         assert dev["model"] == "00000000"
         assert dev["online"] is True
 
+    async def test_list_appliances_non_numeric_model_number(self) -> None:
+        """A non-numeric modelNumber falls back to 0 rather than raising."""
+        cloud = _make_toshiba_cloud(Mock())
+        cloud._access_token = _TOSHIBA_ACCESS_TOKEN
+        with patch.object(
+            cloud,
+            "_api_request",
+            new=AsyncMock(
+                return_value=[
+                    {
+                        "id": "12345678",
+                        "type": "0xAC",
+                        "name": "Living Room AC",
+                        "modelNumber": "RAS-X221DZ",
+                        "onlineStatus": "1",
+                    },
+                ],
+            ),
+        ):
+            appliances = await cloud.list_appliances(None)
+        assert appliances[12345678]["model_number"] == 0
+
     async def test_list_appliances_api_failure(self) -> None:
         """list_appliances returns empty dict when the API returns an error."""
         session = Mock()

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1,5 +1,6 @@
 """Test cloud."""
 
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import ClassVar
@@ -968,17 +969,22 @@ class CloudTest(IsolatedAsyncioTestCase):
             await cloud.download_lua(tmpdir, 10, "00000000", "0xAC", "0010")
 
 
-def _make_toshiba_cloud(session: Mock) -> ToshibaIOLife:
-    """Create a ToshibaIOLife instance with a synthetic app key."""
-    cloud = get_midea_cloud(
-        "Toshiba Iolife",
-        session=session,
-        account="account",
-        password="password",
-    )
-    assert isinstance(cloud, ToshibaIOLife)
-    cloud._app_key = _TOSHIBA_APP_KEY
-    return cloud
+@pytest.fixture(name="make_toshiba_cloud")
+def make_toshiba_cloud_fixture() -> Callable[[Mock], ToshibaIOLife]:
+    """Return a factory for ToshibaIOLife clouds on a mocked session."""
+
+    def _make(session: Mock) -> ToshibaIOLife:
+        cloud = get_midea_cloud(
+            "Toshiba Iolife",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert isinstance(cloud, ToshibaIOLife)
+        cloud._app_key = _TOSHIBA_APP_KEY
+        return cloud
+
+    return _make
 
 
 class TestToshibaDecryptSn:
@@ -995,12 +1001,13 @@ class TestToshibaDecryptSn:
     )
     def test_decrypt_sn(
         self,
+        make_toshiba_cloud: Callable[[Mock], ToshibaIOLife],
         encrypted_sn: str,
         access_token: str | None,
         expected: str,
     ) -> None:
         """_decrypt_sn returns correct SN or '' on error/empty input."""
-        cloud = _make_toshiba_cloud(Mock())
+        cloud = make_toshiba_cloud(Mock())
         cloud._access_token = access_token
         assert cloud._decrypt_sn(encrypted_sn) == expected
 
@@ -1008,19 +1015,30 @@ class TestToshibaDecryptSn:
 class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
     """ToshibaIOLife cloud async tests."""
 
+    responses: ClassVar[dict[str, bytes]] = _RESPONSES
+    make_cloud: Callable[[Mock], ToshibaIOLife]
+
+    @pytest.fixture(autouse=True)
+    def _inject_cloud_factory(
+        self,
+        make_toshiba_cloud: Callable[[Mock], ToshibaIOLife],
+    ) -> None:
+        """Share the cloud factory with these unittest-style tests."""
+        self.make_cloud = make_toshiba_cloud
+
     async def test_list_appliances_success(self) -> None:
         """list_appliances decrypts SN inline and skips virtual devices."""
         session = Mock()
         response = Mock()
         response.read = AsyncMock(
             side_effect=[
-                _RESPONSES["mideaaircloud_login_id.json"],
-                _RESPONSES["mideaaircloud_login.json"],
-                _RESPONSES["toshibaiolife_list_appliances.json"],
+                self.responses["mideaaircloud_login_id.json"],
+                self.responses["mideaaircloud_login.json"],
+                self.responses["toshibaiolife_list_appliances.json"],
             ],
         )
         session.request = AsyncMock(return_value=response)
-        cloud = _make_toshiba_cloud(session)
+        cloud = self.make_cloud(session)
         assert await cloud.login()
         cloud._access_token = _TOSHIBA_ACCESS_TOKEN
 
@@ -1039,7 +1057,7 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
 
     async def test_list_appliances_non_numeric_model_number(self) -> None:
         """A non-numeric modelNumber falls back to 0 rather than raising."""
-        cloud = _make_toshiba_cloud(Mock())
+        cloud = self.make_cloud(Mock())
         cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         with patch.object(
             cloud,
@@ -1064,16 +1082,16 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
         session = Mock()
         response = Mock()
         response.read = AsyncMock(
-            return_value=_RESPONSES["mideaaircloud_invalid_response.json"],
+            return_value=self.responses["mideaaircloud_invalid_response.json"],
         )
         session.request = AsyncMock(return_value=response)
-        cloud = _make_toshiba_cloud(session)
+        cloud = self.make_cloud(session)
         cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         assert await cloud.list_appliances(None) == {}
 
     async def test_list_appliances_non_list_response(self) -> None:
         """list_appliances returns empty dict when the API returns a non-list."""
-        cloud = _make_toshiba_cloud(Mock())
+        cloud = self.make_cloud(Mock())
         cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         with patch.object(
             cloud,
@@ -1092,7 +1110,7 @@ class ToshibaIOLifeTest(IsolatedAsyncioTestCase):
             "onlineStatus": "1",
             "sn": _TOSHIBA_ENCRYPTED_SN,
         }
-        cloud = _make_toshiba_cloud(Mock())
+        cloud = self.make_cloud(Mock())
         cloud._access_token = _TOSHIBA_ACCESS_TOKEN
         with patch.object(
             cloud,

--- a/tests/responses/toshibaiolife_list_appliances.json
+++ b/tests/responses/toshibaiolife_list_appliances.json
@@ -1,0 +1,20 @@
+{
+  "errorCode": "0",
+  "msg": "success",
+  "result": [
+    {
+      "id": "12345678",
+      "name": "Living Room AC",
+      "type": "0xAC",
+      "modelNumber": 10,
+      "sn": "e1f17526c18d049e4862e19f5d6cd269df9b09edd41d4b2627b35dbb2d47b963a433df71998b41d4dc354e9bdf78902a",
+      "onlineStatus": "1"
+    },
+    {
+      "id": "virtual_ag_0xAC",
+      "name": "Virtual Group",
+      "type": "0x_BATCH_AC",
+      "onlineStatus": "1"
+    }
+  ]
+}


### PR DESCRIPTION
Not intended to be merged, but opening a PR to show this is being worked on (slowly), and maybe attract comments and help.

For now, the cloud functions are working (except the one to download lua files, and i suspect that will never work), but that's the only working thing.

The local protocol to actually communicate with the devices is not working at all (yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Toshiba IOLife cloud support for registering accounts and discovering appliances.
  * Added appliance-type retrieval and appliance listings with normalized metadata.
  * Physical appliances now include decrypted serial numbers when available, while virtual devices are excluded.
  * Added support for Toshiba manufacturer identification.

* **Bug Fixes**
  * Invalid or unavailable serial-number data now safely falls back to an empty value.
  * Improved handling of invalid numeric data and cloud API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->