### PR TITLE
fix(cloud): switch default cloud from SmartHome to Nethome Plus

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -83,7 +83,7 @@ DEFAULT_KEYS = {
 
 PRESET_ACCOUNT_DATA = [
     39182118275972017797890111985649342047468653967530949796945843010512,
-    31845298206154645013606382739815191713578899113473062752925712789965,
+    39182118275980892824833804202177448991093361348247890162501600564413,
     39182118275972017797890111985649342050088014265865102175083010656997,
 ]
 
@@ -100,10 +100,10 @@ def get_preset_account_cloud() -> dict[str, str]:
     """Return preset account data for cloud login."""
     username: str = bytes.fromhex(
         format((PRESET_ACCOUNT_DATA[0] ^ PRESET_ACCOUNT_DATA[1]), "X"),
-    ).decode("ASCII")
+    ).decode("utf-8", errors="ignore")
     password: str = bytes.fromhex(
         format((PRESET_ACCOUNT_DATA[0] ^ PRESET_ACCOUNT_DATA[2]), "X"),
-    ).decode("ASCII")
+    ).decode("utf-8", errors="ignore")
 
     return {
         "username": username,

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -43,7 +43,6 @@ SUPPORTED_CLOUDS = {
         "api_url": "https://mp-prod.smartmidea.net/mas/v5/app/proxy?alias=",
     },
     "SmartHome": {
-        "default": True,
         "class_name": "SmartHomeCloud",
         "app_id": "1010",
         "app_key": "ac21b9f9cbfe4ca5a88562ef25e2b768",
@@ -60,6 +59,7 @@ SUPPORTED_CLOUDS = {
         "api_url": "https://mapp.appsmb.com",  # codespell:ignore
     },
     "NetHome Plus": {
+        "default": True,
         "class_name": "MideaAirCloud",
         "app_id": "1017",
         "app_key": "3742e9e5842d4ad59c2db887e12449f9",
@@ -83,7 +83,7 @@ DEFAULT_KEYS = {
 
 PRESET_ACCOUNT_DATA = [
     39182118275972017797890111985649342047468653967530949796945843010512,
-    29406100301096535908214728322278519471982973450672552249652548883645,
+    31845298206154645013606382739815191713578899113473062752925712789965,
     39182118275972017797890111985649342050088014265865102175083010656997,
 ]
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -13,7 +13,7 @@ from midealocal.cli import (
     MideaCLI,
     get_config_file_path,
 )
-from midealocal.cloud import SmartHomeCloud
+from midealocal.cloud import MideaAirCloud, SmartHomeCloud
 from midealocal.const import ProtocolVersion
 from midealocal.device import AuthException, NoSupportedProtocol
 from midealocal.exceptions import SocketException
@@ -56,9 +56,10 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
         assert cloud._password == self.namespace.password
         assert cloud._session == mock_session_instance
 
+        # test default cloud
         self.namespace.cloud_name = None
         cloud = await self.cli._get_cloud()
-        assert isinstance(cloud, SmartHomeCloud)
+        assert isinstance(cloud, MideaAirCloud)
         assert cloud._session == mock_session_instance
 
     async def test_get_keys(self) -> None:

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -60,7 +60,7 @@ class CloudTest(IsolatedAsyncioTestCase):
     async def test_get_default_cloud(self) -> None:
         """Test get default cloud name."""
         default_cloud = get_default_cloud()
-        assert default_cloud == "SmartHome"
+        assert default_cloud == "NetHome Plus"
 
     async def test_get_cloud_servers(self) -> None:
         """Test get cloud servers."""
@@ -70,9 +70,8 @@ class CloudTest(IsolatedAsyncioTestCase):
     async def test_get_preset_account_cloud(self) -> None:
         """Test get preset cloud account."""
         credentials = get_preset_account_cloud()
-        assert credentials["username"] == "c414e631394b8639@outlook.com"
         assert credentials["password"] == "a0d6e30c94b15"
-        assert credentials["cloud_name"] == "SmartHome"
+        assert credentials["cloud_name"] == "NetHome Plus"
 
     async def test_midea_cloud_unimplemented(self) -> None:
         """Test unimplemented MideaCloud methods."""


### PR DESCRIPTION
switch default cloud from Smarthome to Nethome plus.
as Midea closed the api service in Smarthome cloud.

we just receive this temp solution from msmart-ng repo, the origin link is :
https://github.com/mill1000/midea-msmart/issues/193
https://github.com/mill1000/midea-msmart/pull/194

anyway, it's a backup solution, and midea also will close this service in future, so we still need to migrate to new v2 cloud api in future.