### PR TITLE
fix(ac): ac device screen_display status error

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -270,7 +270,9 @@ class MideaACDevice(MideaDevice):
         ):
             self._attributes[DeviceAttributes.indirect_wind] = False
             new_status[DeviceAttributes.indirect_wind.value] = False
-        if not self._attributes[DeviceAttributes.power]:
+        if not self._attributes[DeviceAttributes.power] and (
+            DeviceAttributes.screen_display in new_status
+        ):
             self._attributes[DeviceAttributes.screen_display] = False
             new_status[DeviceAttributes.screen_display.value] = False
         if self._attributes[DeviceAttributes.fresh_air_1] is not None:


### PR DESCRIPTION
fix ac device screen_display error

```
2025-08-05 09:55:38.783 DEBUG (中间卧室空调) [midealocal.devices.ac] [192414535730805] Received: {'_device_type': <DeviceType.AC: 172>, '_message_type': <MessageType.query: 3>, '_body_type': <ListTypes.B1: 177>, '_message_protocol_version': 8, '_header': 'aa32ac00000000000803', '_body': <midealocal.devices.ac.message.XBXMessageBody object at 0x7fc2201dd470>, '_data': 'b108420000010118000000150000001700000164330200004b0000000a0000010009000001005567', 'parser_list': [], '_pack_len': <NewProtocolPackLength.FIVE: 5>, 'indirect_wind': False, 'screen_display_alternate': True, 'screen_display_new': True, 'wind_lr_angle': 0, 'wind_ud_angle': 0, 'header': 'aa32ac00000000000803', 'body': 'b108420000010118000000150000001700000164330200004b0000000a0000010009000001005567', 'message_type': 'query', 'body_type': 'b1', 'self': <midealocal.devices.ac.message.MessageACResponse object at 0x7fc20a79f390>}
2025-08-05 09:55:38.783 DEBUG (中间卧室空调) [midealocal.device] [192414535730805] Status update: {'screen_display_alternate': True, 'indirect_wind': False, 'wind_lr_angle': 'Off', 'wind_ud_angle': 'Off', 'screen_display': False}
```

screen_display should not add to status update when power not exist