### PR TITLE
refactor: improve socket resource management

### DIFF
--- a/midealocal/discover.py
+++ b/midealocal/discover.py
@@ -234,33 +234,33 @@ def discover(
     if discover_type is None:
         discover_type = []
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    sock.settimeout(5)
-    found_devices: dict[int, dict[str, Any]] = {}
-    addrs = enum_all_broadcast() if ip_address is None else [ip_address]
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.settimeout(5)
+        found_devices: dict[int, dict[str, Any]] = {}
+        addrs = enum_all_broadcast() if ip_address is None else [ip_address]
 
-    _LOGGER.debug("All addresses for broadcast: %s", addrs)
-    for addr in addrs:
-        try:
-            sock.sendto(BROADCAST_MSG, (addr, 6445))
-            sock.sendto(BROADCAST_MSG, (addr, 20086))
-        except OSError as e:
-            _LOGGER.warning("Can't access network %s: %s", addrs, repr(e))
-    while True:
-        try:
-            device_id, device = _parse_discover_response(sock, found_devices)
-            if device is None:
-                continue
-            if len(discover_type) == 0 or device.get("type") in discover_type:
-                found_devices[device_id] = device
-                _LOGGER.debug("Found a supported device: %s", device)
-            else:
-                _LOGGER.debug("Found a unsupported device: %s", device)
-        except TimeoutError:
-            break
-        except OSError:
-            _LOGGER.exception("Socket error")
+        _LOGGER.debug("All addresses for broadcast: %s", addrs)
+        for addr in addrs:
+            try:
+                sock.sendto(BROADCAST_MSG, (addr, 6445))
+                sock.sendto(BROADCAST_MSG, (addr, 20086))
+            except OSError as e:
+                _LOGGER.warning("Can't access network %s: %s", addrs, repr(e))
+        while True:
+            try:
+                device_id, device = _parse_discover_response(sock, found_devices)
+                if device is None:
+                    continue
+                if len(discover_type) == 0 or device.get("type") in discover_type:
+                    found_devices[device_id] = device
+                    _LOGGER.debug("Found a supported device: %s", device)
+                else:
+                    _LOGGER.debug("Found a unsupported device: %s", device)
+            except TimeoutError:
+                break
+            except OSError:
+                _LOGGER.exception("Socket error")
     return found_devices
 
 


### PR DESCRIPTION
This commit introduces several improvements to how sockets are handled to make the code more robust and prevent potential resource leaks.

- In `midealocal/discover.py`, the discovery socket is now managed with a `with` statement, ensuring it is always closed correctly, even if errors occur.

- In `midealocal/device.py`, the `connect` method is updated to only assign the socket to the instance after a successful connection. If the connection fails at any point, the created socket is now properly closed.

- The `disconnect` method now wraps the socket shutdown and close calls in a `try/finally` block to guarantee that `socket.close()` is executed.