### PR TITLE
fix(cd): don't let SET echo clobber power state (draft, needs device validation)

### DIFF
--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Unpack
 
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs
+from midealocal.message import MessageType
 
 from .message import (
     MessageCDBase,
@@ -253,6 +254,14 @@ class MideaCDDevice(MideaDevice):
         message = MessageCDResponse(msg)
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status: dict[str, Any] = {}
+        # SET echoes are known to carry junk in several body positions (see the
+        # openPTC/Tr and mode-echo notes below).  Treat the "power" bit from a
+        # SET echo as untrusted: a spurious power=0 echo must not overwrite a
+        # good ON reading, because the stored power is later replayed into every
+        # temperature/mode control frame and would silently switch the unit off
+        # (see midea_ac_lan#768).  Genuine status/notify/query frames still
+        # update power normally.  Unknown/mocked messages keep prior behaviour.
+        is_set_echo = getattr(message, "message_type", None) == MessageType.set
         if hasattr(message, "fields"):
             self._fields = message.fields
         # parse fahrenheit switch for temperature value
@@ -358,6 +367,12 @@ class MideaCDDevice(MideaDevice):
                         else:
                             self._attributes[attr] = None
                             new_status[str(attr)] = None
+                    continue
+                # Do not let a SET echo clobber the trusted power state; a
+                # bogus power=0 echo would be replayed as an OFF command on the
+                # next temperature/mode write (midea_ac_lan#768).
+                if attr == DeviceAttributes.power and is_set_echo:
+                    new_status[str(attr)] = self._attributes[attr]
                     continue
                 # non-temperature attributes
                 self._attributes[attr] = raw_value

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from midealocal.const import ProtocolVersion
 from midealocal.devices.cd import DeviceAttributes, MideaCDDevice
+from midealocal.message import MessageType
 
 
 class TestMideaCDDevice:
@@ -197,6 +198,48 @@ class TestMideaCDDevice:
         assert status[DeviceAttributes.auto_sterilize_week.value] == 4
         assert status[DeviceAttributes.auto_sterilize_hour.value] == 14
         assert status[DeviceAttributes.auto_sterilize_minute.value] == 5
+
+    # ------------------------------------------------------------------ #
+    # power must survive a SET echo (midea_ac_lan#768)                    #
+    # ------------------------------------------------------------------ #
+
+    def test_set_echo_does_not_clobber_power(self) -> None:
+        """A SET echo with power=False must not overwrite a trusted ON state.
+
+        Otherwise the stale OFF is replayed into the next temperature/mode
+        control frame and silently switches the unit off.
+        """
+        self.device._attributes[DeviceAttributes.power] = True
+
+        class FakeSetEcho:
+            message_type = MessageType.set
+            power = False
+
+        with patch(
+            "midealocal.devices.cd.MessageCDResponse",
+            return_value=FakeSetEcho(),
+        ):
+            status = self.device.process_message(b"")
+
+        assert self.device._attributes[DeviceAttributes.power] is True
+        assert status[DeviceAttributes.power.value] is True
+
+    def test_status_frame_updates_power(self) -> None:
+        """A genuine status/notify frame still updates the power state."""
+        self.device._attributes[DeviceAttributes.power] = True
+
+        class FakeStatus:
+            message_type = MessageType.notify1
+            power = False
+
+        with patch(
+            "midealocal.devices.cd.MessageCDResponse",
+            return_value=FakeStatus(),
+        ):
+            status = self.device.process_message(b"")
+
+        assert self.device._attributes[DeviceAttributes.power] is False
+        assert status[DeviceAttributes.power.value] is False
 
     # ------------------------------------------------------------------ #
     # disinfection_temperature is read-only for CD                         #


### PR DESCRIPTION
> **Draft — needs validation on real CD hardware before merge.** See "Validation needed" below.

## Problem

On CD water heaters, a pure `target_temperature` (or `mode`) SET can silently switch the unit **OFF**.

Every power/mode/temperature write goes out as a single `controlType=0x01` frame that bundles **all three** fields (`midealocal/devices/cd/__init__.py`):

```python
current_power = self._attributes.get(DeviceAttributes.power, False)   # ~L404
...
message.power = current_power                                          # ~L411
...
elif attr == DeviceAttributes.target_temperature:
    message.target_temperature = float(value)                         # never touches message.power
```

For a temperature-only change, `message.power` is whatever `_attributes[power]` currently holds. If that stored value is wrongly `False`, the setpoint change commands the device off.

## Root cause

`process_message` accepts the `power` bit from **every** frame via the generic store path, with **no SET-echo guard** — unlike `mode`, which is already guarded (only recognised keys accepted). SET echoes are known to carry junk in this device (see the many `openPTC`/`Tr`/mode-echo notes in the file). A spurious `power=0` echo overwrites a good ON reading, and that stale OFF is then replayed as an OFF command on the next temperature/mode write.

## Fix

Distrust the `power` bit from SET echoes (`message_type == MessageType.set`), exactly as `mode` is already distrusted. Genuine `status`/`notify`/`query` frames still update `power` normally. Unknown/mocked messages keep prior behaviour (safe for existing tests).

- `+8` lines in `process_message` (compute `is_set_echo`, skip power overwrite on echo)
- `+2` regression tests: echo must not clobber ON; genuine status frame still updates power

## Why here and not in Home Assistant

The downstream integration PR wuwentao/midea_ac_lan#768 worked around this at the entity layer by forcing `power=True` before every setpoint write. That (a) makes it impossible to set a target temperature while the heater is intentionally OFF, and (b) emits two control frames. Fixing it here keeps the entity layer honest.

## Test / lint

```
pytest tests/devices/cd/    ->  65 passed
ruff check (changed files)  ->  All checks passed
ruff format --check         ->  already formatted
mypy midealocal/devices/cd  ->  Success: no issues found
```

## Validation needed before merge

I don't have CD hardware, so please confirm on a real unit + debug log:

1. **SET echoes actually arrive as `message_type == MessageType.set`** (0x02). If a CD SET echo is instead delivered as a notify frame, the guard needs to key off a different discriminator.
2. **After a temperature-only change, a genuine status/notify frame follows** so `_attributes[power]` reconciles quickly (the guard intentionally does not optimistically flip power on a SET echo).
3. Whether the **pre-first-status** default (`power=False` at init, ~L117) also needs handling — deliberately left out of this PR to keep scope tight; can add a follow-up if a temp-set can realistically precede the first status frame.

Refs: wuwentao/midea_ac_lan#768
