### PR TITLE
fix(ac): keep unit on when a mode change is followed by a temperature write

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -857,6 +857,15 @@ class MideaACDevice(MideaDevice):
                     # Force fan_speed to AUTO when leaving DRY mode
                     if self._attributes[DeviceAttributes.mode] == DRY_MODE:
                         message.fan_speed = 102
+                    # Optimistically reflect the commanded state in the cache so
+                    # an immediate follow-up write (e.g. set_target_temperature,
+                    # which serializes a full packet from make_message_uniq_set)
+                    # is built from power=True and the new mode. Without this the
+                    # follow-up reuses the stale last-confirmed power=False and
+                    # turns the unit back off before the mode response arrives.
+                    # https://github.com/midea-lan/midea-local/issues/495
+                    self._attributes[DeviceAttributes.power] = True
+                    self._attributes[DeviceAttributes.mode] = value
         if message is not None:
             self.build_send(message)
 

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -230,6 +230,36 @@ class TestMideaACDevice:
             assert message.dry is False
             assert message.fan_speed == 102
 
+    def test_set_mode_then_temperature_keeps_unit_on(self) -> None:
+        """A mode change followed immediately by a temperature write stays on.
+
+        set_attribute("mode") only forced power=True on the outgoing packet, so
+        a rapid follow-up set_target_temperature (built from make_message_uniq_set)
+        reused the stale last-confirmed power=False and turned the unit back off.
+        The mode change now optimistically caches power=True + the new mode.
+        https://github.com/midea-lan/midea-local/issues/495
+        """
+        # Start from the confirmed "off" state, as after a fresh query.
+        self.device._attributes[DeviceAttributes.power] = False
+        self.device._attributes[DeviceAttributes.mode] = 0
+        with patch.object(self.device, "build_send") as mock_build_send:
+            # 1. set HVAC mode to cool (value 2)
+            self.device.set_attribute(DeviceAttributes.mode.value, 2)
+            mode_message = mock_build_send.call_args[0][0]
+            assert mode_message.power is True
+            assert mode_message.mode == 2
+            # Cache reflects the commanded state before the device responds.
+            assert self.device.attributes[DeviceAttributes.power] is True
+            assert self.device.attributes[DeviceAttributes.mode] == 2
+
+            # 2. immediately set target temperature (mode=None, as the climate
+            #    entity does) - must not resurrect the stale power=False.
+            self.device.set_target_temperature(21, None)
+            temp_message = mock_build_send.call_args[0][0]
+            assert temp_message.power is True
+            assert temp_message.mode == 2
+            assert temp_message.target_temperature == 21
+
     def test_customize_temperature_limits(self) -> None:
         """Test customize min/max temperature limits."""
         self.device.set_customize('{"min_temperature": 17, "max_temperature": 28}')


### PR DESCRIPTION
## Summary

Two AC writes sent back-to-back — `set_hvac_mode(cool)` then `set_target_temperature(21)` — could make the unit briefly turn on and then immediately turn **back off** (reported on a Midea PortaSplit; state history showed `cool` → `off` ~138 ms later).

Root cause: `set_attribute("mode", ...)` forces `power=True` **only on the outgoing packet**, not in the cached attributes. The immediately-following `set_target_temperature(mode=None)` builds a *full* packet from `make_message_uniq_set()`, which reads the still-stale last-confirmed `power=False`. That second packet therefore serialized `power=False` and turned the unit off. Inserting a ~2 s delay between the two writes hid the race, because the mode response updated the cache in between.

## Fix

After the mode packet is built (and after the DRY-mode fan reset, which reads the *old* mode), optimistically reflect the commanded state in the cached attributes:

```python
self._attributes[DeviceAttributes.power] = True
self._attributes[DeviceAttributes.mode] = value
```

So an immediate follow-up write is serialized from the intended `power=True` + new mode instead of the stale confirmed state. The real device response still overwrites the cache when it arrives (matching the optimistic-update pattern the integration already relies on).

## Changes

- `midealocal/devices/ac/__init__.py`: optimistic cache update in the `mode` branch of `set_attribute`.

## Tests

- Added `test_set_mode_then_temperature_keeps_unit_on`: from a confirmed `power=False, mode=0` state, `set_attribute("mode", cool)` then `set_target_temperature(21, None)` — asserts both packets carry `power=True`, mode `cool`, and the cache is updated. Verified this test **fails without the fix** (the follow-up packet's `power` was `False`) and passes with it.

## Verification

- `uv run python -m pytest tests/devices/ac/` — 131 passed
- `uvx ruff@0.6.9 check` / `format --check` — clean
- `uv run mypy midealocal` — Success
- `uv run pylint --rcfile=pylintrc midealocal` — 10.00/10

Fixes #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the air conditioner’s mode now immediately reflects the selected mode and power-on state.
  * Setting the temperature immediately after changing modes now preserves the latest commands instead of using stale device state.

* **Tests**
  * Added regression coverage for consecutive mode and temperature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->