### PR TITLE
fix(cd)!: modes snakecase

### DIFF
--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -94,12 +94,12 @@ class MideaCDDevice(MideaDevice):
     """Midea CD device."""
 
     _modes: ClassVar[dict[int, str]] = {
-        0x00: "None",
-        0x01: "Energy-save",
-        0x02: "Standard",
-        0x03: "Dual",
-        0x04: "Smart",
-        0x05: "Vacation",
+        0x00: "none",
+        0x01: "energy_save",
+        0x02: "standard",
+        0x03: "dual",
+        0x04: "smart",
+        0x05: "vacation",
     }
     _vacation_mode_key: ClassVar[int] = 0x05
 
@@ -457,9 +457,9 @@ class MideaCDDevice(MideaDevice):
             # Note: when vacation is active the stored mode is "Vacation" (0x05)
             # which is NOT a valid modeValue for the device.  We handle that
             # explicitly in the vacation branches below.
-            if current_mode is None or current_mode == "None":
+            if current_mode is None or current_mode == "none":
                 message.mode = 0x00
-            elif current_mode == "Vacation":
+            elif current_mode == "vacation":
                 # Do not send 0x05 as modeValue; the device does not support it.
                 # Fall back to 0x00 (no explicit operating mode).
                 message.mode = 0x00

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -84,8 +84,8 @@ class TestMideaCDDevice:
 
     def test_preset_modes_excludes_vacation_from_selectable_modes(self) -> None:
         """Vacation is readable state, not directly selectable operation mode."""
-        assert "Vacation" not in self.device.preset_modes
-        assert self.device._modes[0x05] == "Vacation"
+        assert "vacation" not in self.device.preset_modes
+        assert self.device._modes[0x05] == "vacation"
 
     def test_set_mode_vacation_is_rejected(self) -> None:
         """Direct Vacation operation mode writes are blocked."""
@@ -391,7 +391,7 @@ class TestMideaCDDevice:
             _build_message(MessageType.query, _general_body()),
         )
         assert self.device.attributes[DeviceAttributes.power] is True
-        assert self.device.attributes[DeviceAttributes.mode] == "Standard"
+        assert self.device.attributes[DeviceAttributes.mode] == "standard"
         assert self.device.attributes[DeviceAttributes.target_temperature] == 40
         assert self.device.attributes[DeviceAttributes.current_temperature] == 35
         assert self.device.attributes[DeviceAttributes.outdoor_temperature] == 20
@@ -405,7 +405,7 @@ class TestMideaCDDevice:
         assert self.device.attributes[DeviceAttributes.error_code] == 3
         assert self.device.attributes[DeviceAttributes.disinfection_temperature] == 65.0
         assert self.device.attributes[DeviceAttributes.fahrenheit] is False
-        assert new_status[DeviceAttributes.mode.value] == "Standard"
+        assert new_status[DeviceAttributes.mode.value] == "standard"
 
     def test_process_vacation_status_message(self) -> None:
         """Vacation bit in body[35] maps to Vacation mode and days."""
@@ -414,7 +414,7 @@ class TestMideaCDDevice:
         body[36] = 0x00
         body[37] = 30
         self.device.process_message(_build_message(MessageType.query, body))
-        assert self.device.attributes[DeviceAttributes.mode] == "Vacation"
+        assert self.device.attributes[DeviceAttributes.mode] == "vacation"
         assert self.device.attributes[DeviceAttributes.vacation_mode] is True
         assert self.device.attributes[DeviceAttributes.vacation_days] == 30
 
@@ -446,7 +446,7 @@ class TestMideaCDDevice:
             "byte8": 0x10,
         }
         assert self.device.attributes[DeviceAttributes.power] is True
-        assert self.device.attributes[DeviceAttributes.mode] == "Standard"
+        assert self.device.attributes[DeviceAttributes.mode] == "standard"
         assert self.device.attributes[DeviceAttributes.target_temperature] == 40
         assert self.device.attributes[DeviceAttributes.vacation_mode] is True
         assert self.device.attributes[DeviceAttributes.vacation_days] == 30
@@ -623,7 +623,7 @@ class TestMideaCDDevice:
 
     def test_set_power_with_known_mode_state(self) -> None:
         """Stored Standard mode maps back to its key."""
-        self.device._attributes[DeviceAttributes.mode] = "Standard"
+        self.device._attributes[DeviceAttributes.mode] = "standard"
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()
@@ -632,7 +632,7 @@ class TestMideaCDDevice:
 
     def test_set_power_with_none_string_mode_state(self) -> None:
         """Stored "None" mode maps to 0x00."""
-        self.device._attributes[DeviceAttributes.mode] = "None"
+        self.device._attributes[DeviceAttributes.mode] = "none"
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()
@@ -648,7 +648,7 @@ class TestMideaCDDevice:
     def test_set_mode_standard(self) -> None:
         """A valid mode value is mapped to its key and sent."""
         with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.mode.value, "Standard")
+            self.device.set_attribute(DeviceAttributes.mode.value, "standard")
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
             assert msg.mode == 0x02

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -90,7 +90,7 @@ class TestMideaCDDevice:
     def test_set_mode_vacation_is_rejected(self) -> None:
         """Direct Vacation operation mode writes are blocked."""
         with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.mode.value, "Vacation")
+            self.device.set_attribute(DeviceAttributes.mode.value, "vacation")
             mock_send.assert_not_called()
 
     def test_set_power_uses_ts_max_at_body_23(self) -> None:

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -115,7 +115,7 @@ class TestMideaCDDevice:
         self.device._attributes[DeviceAttributes.max_temperature] = 65.0
         self.device._attributes[DeviceAttributes.target_temperature] = 60.0
         self.device._attributes[DeviceAttributes.power] = True
-        self.device._attributes[DeviceAttributes.mode] = "Standard"
+        self.device._attributes[DeviceAttributes.mode] = "standard"
 
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.target_temperature.value, 63.0)
@@ -614,7 +614,7 @@ class TestMideaCDDevice:
 
     def test_set_power_with_vacation_mode_state(self) -> None:
         """Stored Vacation mode is never sent as a modeValue."""
-        self.device._attributes[DeviceAttributes.mode] = "Vacation"
+        self.device._attributes[DeviceAttributes.mode] = "vacation"
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated device mode values to use consistent lowercase identifiers.
  * Improved handling for “none” and “vacation” modes when changing settings.
  * Preserved existing mode mapping and command behavior.
  * Ensured mode selections are interpreted consistently across device controls and settings.
  * Improved compatibility with integrations that rely on standardized lowercase mode values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->