### PR TITLE
fix(e1)!: snakecase standard

### DIFF
--- a/midealocal/devices/e1/__init__.py
+++ b/midealocal/devices/e1/__init__.py
@@ -90,38 +90,38 @@ class MideaE1Device(MideaDevice):
             },
         )
         self._modes = {
-            0x00: "Neutral Gear",  # BYTE_MODE_NEUTRAL_GEAR
-            0x01: "Auto Wash",  # BYTE_MODE_AUTO_WASH
-            0x02: "Strong Wash",  # BYTE_MODE_STRONG_WASH
-            0x03: "Standard Wash",  # BYTE_MODE_STANDARD_WASH
-            0x04: "ECO Wash",  # BYTE_MODE_ECO_WASH
-            0x05: "Glass Wash",  # BYTE_MODE_GLASS_WASH
-            0x06: "Hour Wash",  # BYTE_MODE_HOUR_WASH
-            0x07: "Fast Wash",  # BYTE_MODE_FAST_WASH
-            0x08: "Soak Wash",  # BYTE_MODE_SOAK_WASH
-            0x09: "90Min",  # BYTE_MODE_90MIN_WASH
-            0x0A: "Self Clean",  # BYTE_MODE_SELF_CLEAN
-            0x0B: "Fruit Wash",  # BYTE_MODE_FRUIT_WASH
-            0x0C: "Self Define",  # BYTE_MODE_SELF_DEFINE
-            0x0D: "Germ",  # BYTE_MODE_GERM ???
-            0x0E: "Bowl Wash",  # BYTE_MODE_BOWL_WASH
-            0x0F: "Kill Germ",  # BYTE_MODE_KILL_GERM
-            0x10: "Sea Food Wash",  # BYTE_MODE_SEA_FOOD_WASH
-            0x12: "Hot Pot Wash",  # BYTE_MODE_HOT_POT_WASH
-            0x13: "Quiet Night Wash",  # BYTE_MODE_QUIET_NIGHT_WASH
-            0x14: "Less Wash",  # BYTE_MODE_LESS_WASH
-            0x16: "Oil Net Wash",  # BYTE_MODE_OIL_NET_WASH
-            0x19: "Cloud Wash",  # BYTE_MODE_CLOUD_WASH
+            0x00: "neutral_gear",  # BYTE_MODE_NEUTRAL_GEAR
+            0x01: "auto_wash",  # BYTE_MODE_AUTO_WASH
+            0x02: "strong_wash",  # BYTE_MODE_STRONG_WASH
+            0x03: "standard_wash",  # BYTE_MODE_STANDARD_WASH
+            0x04: "eco_wash",  # BYTE_MODE_ECO_WASH
+            0x05: "glass_wash",  # BYTE_MODE_GLASS_WASH
+            0x06: "hour_wash",  # BYTE_MODE_HOUR_WASH
+            0x07: "fast_wash",  # BYTE_MODE_FAST_WASH
+            0x08: "soak_wash",  # BYTE_MODE_SOAK_WASH
+            0x09: "90min",  # BYTE_MODE_90MIN_WASH
+            0x0A: "self_clean",  # BYTE_MODE_SELF_CLEAN
+            0x0B: "fruit_wash",  # BYTE_MODE_FRUIT_WASH
+            0x0C: "self_define",  # BYTE_MODE_SELF_DEFINE
+            0x0D: "germ",  # BYTE_MODE_GERM ???
+            0x0E: "bowl_wash",  # BYTE_MODE_BOWL_WASH
+            0x0F: "kill_germ",  # BYTE_MODE_KILL_GERM
+            0x10: "sea_food_wash",  # BYTE_MODE_SEA_FOOD_WASH
+            0x12: "hot_pot_wash",  # BYTE_MODE_HOT_POT_WASH
+            0x13: "quiet_night_wash",  # BYTE_MODE_QUIET_NIGHT_WASH
+            0x14: "less_wash",  # BYTE_MODE_LESS_WASH
+            0x16: "oil_net_wash",  # BYTE_MODE_OIL_NET_WASH
+            0x19: "cloud_wash",  # BYTE_MODE_CLOUD_WASH
         }
         self._status = {
-            0x00: "Power Off",
-            0x01: "Cancel",
-            0x02: "Delay",
-            0x03: "Running",
-            0x04: "Error",
-            0x05: "Soft Gear",
+            0x00: "off",
+            0x01: "cancel",
+            0x02: "delay",
+            0x03: "running",
+            0x04: "error",
+            0x05: "soft_gear",
         }
-        self._progress = ["Idle", "Pre-wash", "Wash", "Rinse", "Dry", "Complete"]
+        self._progress = ["idle", "pre_wash", "wash", "rinse", "dry", "complete"]
 
     @property
     def modes(self) -> dict[int, str]:

--- a/tests/devices/e1/device_e1_test.py
+++ b/tests/devices/e1/device_e1_test.py
@@ -75,7 +75,7 @@ class TestMideaE1Device:
         assert isinstance(message, MessageWork)
         assert message.mode == 0x04
 
-    @pytest.mark.parametrize("mode", [None, 0, "Neutral Gear"])
+    @pytest.mark.parametrize("mode", [None, 0, "neutral_gear"])
     def test_start_work_requires_selected_mode(self, mode: str | int | None) -> None:
         """Test starting requires a non-neutral selected mode."""
         self.device._attributes[DeviceAttributes.mode] = mode

--- a/tests/devices/e1/device_e1_test.py
+++ b/tests/devices/e1/device_e1_test.py
@@ -41,9 +41,9 @@ class TestMideaE1Device:
     def test_modes(self) -> None:
         """Test work modes are exposed without allowing mutation."""
         modes = self.device.modes
-        assert modes[0x04] == "ECO Wash"
-        modes[0x04] = "Changed"
-        assert self.device.modes[0x04] == "ECO Wash"
+        assert modes[0x04] == "eco_wash"
+        modes[0x04] = "changed"
+        assert self.device.modes[0x04] == "eco_wash"
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -67,7 +67,7 @@ class TestMideaE1Device:
 
     def test_start_work(self) -> None:
         """Test starting the currently selected work mode."""
-        self.device._attributes[DeviceAttributes.mode] = "ECO Wash"
+        self.device._attributes[DeviceAttributes.mode] = "eco_wash"
         with patch.object(self.device, "build_send") as mock_build_send:
             self.device.start_work()
 
@@ -99,16 +99,16 @@ class TestMideaE1Device:
     def test_process_message_maps_status_progress_and_mode(self) -> None:
         """Test process message maps status, progress and mode via lookup tables."""
         body = bytearray(40)
-        body[1] = 0x03  # status Running
-        body[2] = 0x04  # mode ECO Wash
-        body[9] = 0x03  # progress Rinse
+        body[1] = 0x03  # status running
+        body[2] = 0x04  # mode eco_wash
+        body[9] = 0x03  # progress rinse
         new_status = self.device.process_message(
             self._message(MessageType.query, body),
         )
-        assert self.device.attributes[DeviceAttributes.status] == "Running"
-        assert self.device.attributes[DeviceAttributes.mode] == "ECO Wash"
-        assert self.device.attributes[DeviceAttributes.progress] == "Rinse"
-        assert new_status[DeviceAttributes.status.value] == "Running"
+        assert self.device.attributes[DeviceAttributes.status] == "running"
+        assert self.device.attributes[DeviceAttributes.mode] == "eco_wash"
+        assert self.device.attributes[DeviceAttributes.progress] == "rinse"
+        assert new_status[DeviceAttributes.status.value] == "running"
 
     def test_process_message_unknown_status_mode_and_progress(self) -> None:
         """Test process message returns None for unmapped lookup values."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized E1 device mode, status, and progress labels to lowercase, underscore-separated values for more consistent display and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->