### PR TITLE
chore: force last release sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "include-commit-authors": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
+  "last-release-sha": "999f49505bad380e45a80d201e95145a90ca411f",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
SHA calculated with:

- `git fetch --all`
- `git rev-list -n 1 "midea-local-v8.0.1"`

where `midea-local-v8.0.1` was the latest released tag at the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tracking configuration to ensure future releases start from the correct baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->