### PR TITLE
fix(ce): improve modes naming

### DIFF
--- a/midealocal/devices/ce/__init__.py
+++ b/midealocal/devices/ce/__init__.py
@@ -39,7 +39,7 @@ class DeviceAttributes(StrEnum):
 class MideaCEDevice(MideaDevice):
     """Midea CE device."""
 
-    _modes: ClassVar[list[str]] = ["normal", "sleep", "eco"]
+    _modes: ClassVar[list[str]] = ["none", "sleep", "eco"]
 
     def __init__(
         self,
@@ -100,7 +100,7 @@ class MideaCEDevice(MideaDevice):
         elif self._attributes[DeviceAttributes.eco_mode]:
             self._attributes[DeviceAttributes.mode] = "eco"
         else:
-            self._attributes[DeviceAttributes.mode] = "normal"
+            self._attributes[DeviceAttributes.mode] = "none"
         new_status[DeviceAttributes.mode.value] = self._attributes[
             DeviceAttributes.mode
         ]

--- a/tests/devices/ce/device_ce_test.py
+++ b/tests/devices/ce/device_ce_test.py
@@ -54,7 +54,7 @@ class TestMideaCEDevice:
         assert self.device.attributes[DeviceAttributes.filter_change_reminder] is False
         assert self.device.attributes[DeviceAttributes.error_code] == 0
         assert self.device.speed_count == 7
-        assert self.device.preset_modes == ["normal", "sleep", "eco"]
+        assert self.device.preset_modes == ["none", "sleep", "eco"]
 
     def test_build_query(self) -> None:
         """Test build query."""
@@ -165,7 +165,7 @@ class TestMideaCEDevice:
         assert self.device.attributes[DeviceAttributes.current_temperature] == 5.0
         assert self.device.attributes[DeviceAttributes.hcho] == 0.1
         assert self.device.attributes[DeviceAttributes.error_code] == 3
-        assert self.device.attributes[DeviceAttributes.mode] == "normal"
+        assert self.device.attributes[DeviceAttributes.mode] == "none"
 
     def test_notify_response_sensor_sentinels(self) -> None:
         """Test notify1 response with 0xFF sensor sentinels."""
@@ -192,14 +192,14 @@ class TestMideaCEDevice:
         body[0] = 0x01
         crc = bytearray([0x00])
         new_status = self.device.process_message(bytes(header + body + crc))
-        assert new_status == {DeviceAttributes.mode.value: "normal"}
+        assert new_status == {DeviceAttributes.mode.value: "none"}
 
     @pytest.mark.parametrize(
         ("value", "sleep_mode", "eco_mode"),
         [
             ("sleep", True, False),
             ("eco", False, True),
-            ("normal", False, False),
+            ("none", False, False),
         ],
     )
     def test_set_attribute_mode(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CE device mode reporting to use **“none”** when neither sleep nor eco mode is active.
  * Corrected the available preset modes to include **“none”** instead of **“normal.”**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->