### PR TITLE
fix(ac): missing B5-derived modes

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -517,7 +517,7 @@ class MideaACDevice(MideaDevice):
             self._fresh_air_version = DeviceAttributes.fresh_air_2
         new_status.update(self._refresh_self_clean_status(message))
         new_status.update(self._refresh_temperature_limits(message))
-        self._update_capabilities(message)
+        new_status.update(self._update_capabilities(message))
         return new_status
 
     @staticmethod
@@ -545,10 +545,23 @@ class MideaACDevice(MideaDevice):
             else self._default_refresh_interval
         )
 
-    def _update_capabilities(self, message: MessageACResponse) -> None:
-        """Accumulate decoded B5 capability flags from a B5 response."""
-        if hasattr(message, "capabilities"):
-            self._capabilities.update(message.capabilities)
+    def _update_capabilities(self, message: MessageACResponse) -> dict[str, Any]:
+        """Accumulate decoded B5 capability flags from a B5 response.
+
+        Returns a status delta so a capability-only frame (no DeviceAttributes
+        changed) still reaches update_all(); callers that derive state from
+        `capabilities` would otherwise never be notified of the change.
+        """
+        if not hasattr(message, "capabilities"):
+            return {}
+        new_capabilities = message.capabilities
+        if all(
+            self._capabilities.get(key) == value
+            for key, value in new_capabilities.items()
+        ):
+            return {}
+        self._capabilities.update(new_capabilities)
+        return {"capabilities": dict(self._capabilities)}
 
     def _refresh_self_clean_status(self, message: MessageACResponse) -> dict[str, Any]:
         """Apply a reported self-clean status, ignoring stale readings.

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -556,6 +556,31 @@ class TestMideaACDevice:
             "anion": True,
         }
 
+    def test_process_message_reports_capabilities_only_change(self) -> None:
+        """A capability-only frame must still produce a non-empty status delta.
+
+        `Device.parse_message` only calls `update_all` (and so notifies
+        callback-driven consumers, e.g. entities deriving state from
+        `capabilities`) when `process_message` returns a non-empty dict.
+        """
+        body = bytearray([0xB5, 0x01])
+        body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
+
+        status = self.device.process_message(self._response(body))
+
+        assert status.get("capabilities") == self.device.capabilities
+        assert self.device.capabilities["heat_mode"] is True
+
+    def test_process_message_capabilities_unchanged_is_a_no_op(self) -> None:
+        """A repeated, identical capability frame reports no delta the second time."""
+        body = bytearray([0xB5, 0x01])
+        body += bytearray([0x14, 0x02, 0x01, 7])  # b5_mode
+
+        self.device.process_message(self._response(body))
+        status = self.device.process_message(self._response(body))
+
+        assert "capabilities" not in status
+
     def test_process_message(self) -> None:
         """Test process message."""
         with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device status updates now report newly detected capability changes.
  * Repeated, unchanged capability information no longer produces redundant updates.
  * Heat-mode capability state is updated correctly when new device information is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->