### PR TITLE
fix(x13)!: improve effects naming

### DIFF
--- a/midealocal/devices/x13/__init__.py
+++ b/midealocal/devices/x13/__init__.py
@@ -27,7 +27,7 @@ class Midea13Device(MideaDevice):
     """Midea x13 Device."""
 
     _effects: ClassVar[list[str]] = [
-        "manual",
+        "none",
         "living",
         "reading",
         "mildly",

--- a/tests/devices/x13/device_x13_test.py
+++ b/tests/devices/x13/device_x13_test.py
@@ -42,7 +42,7 @@ class TestMidea13Device:
     def test_effects(self) -> None:
         """Test effects property."""
         assert self.device.effects == [
-            "manual",
+            "none",
             "living",
             "reading",
             "mildly",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the X13 device effect list to correctly show “none” instead of “manual.”
  * Corrected the associated effect validation to reflect the updated option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->