### PR TITLE
fix(device): prevent appliance query from masking failed status queries

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -479,9 +479,10 @@ class MideaDevice(threading.Thread):
 
     def refresh_status(self, check_protocol: bool = False) -> None:
         """Refresh device status."""
-        cmds: list = self.build_query()
+        real_cmds: list = self.build_query()
+        cmds = real_cmds
         if self._appliance_query:
-            cmds = [MessageQueryAppliance(self.device_type), *cmds]
+            cmds = [MessageQueryAppliance(self.device_type), *real_cmds]
         error_count = 0
         _LOGGER.debug(
             "[%s] refresh_status with cmds: %s, check_protocol %s, \
@@ -530,7 +531,8 @@ class MideaDevice(threading.Thread):
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
                     except TimeoutError:
-                        error_count += 1
+                        if cmd in real_cmds:
+                            error_count += 1
                         self._unsupported_protocol.append(cmd.__class__.__name__)
                         _LOGGER.debug(
                             "[%s] Does not supports the protocol %s, cmd %s, ignored",
@@ -540,7 +542,8 @@ class MideaDevice(threading.Thread):
                         )
                     except ResponseException:
                         # parse msg error
-                        error_count += 1
+                        if cmd in real_cmds:
+                            error_count += 1
                         _LOGGER.debug(
                             "[%s] refresh_status ResponseException %s, cmd %s",
                             self._device_id,
@@ -553,9 +556,12 @@ class MideaDevice(threading.Thread):
                     self._device_id,
                     cmd,
                 )
-                error_count += 1
-            # all the query failed
-            if error_count == len(cmds):
+                if cmd in real_cmds:
+                    error_count += 1
+            # A successful appliance query is not device status: it must not mask
+            # every real status query failing. Guard against a subclass whose
+            # build_query() returns [], where "all failed" would be vacuous.
+            if real_cmds and error_count == len(real_cmds):
                 _LOGGER.debug(
                     "[%s] all the query cmds failed %s, please report bug",
                     self._device_id,

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -576,9 +576,11 @@ class TestMideaDevice:
         with pytest.raises(NotImplementedError):
             self.device.refresh_status()  # build_query not implemented
 
+        self.device._appliance_query = False
+        real_cmd = MagicMock()
         socket_mock = MagicMock()
         with (
-            patch.object(self.device, "build_query", return_value=[]),
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
             patch.object(
                 socket_mock,
                 "recv",
@@ -620,6 +622,66 @@ class TestMideaDevice:
                 self.device.refresh_status(True)  # Timeout
             with pytest.raises(NoSupportedProtocol):
                 self.device.refresh_status(True)  # Unsupported protocol
+
+    def test_refresh_status_appliance_success_does_not_mask_query_failure(self) -> None:
+        """Regression test for #575: appliance success must not mask query timeouts."""
+        real_cmd = MagicMock()
+        self.device._socket = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(
+                self.device._socket,
+                "recv",
+                side_effect=[bytearray([0x0]), TimeoutError()],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[MessageResult.SUCCESS],
+            ),
+        ):
+            assert self.device._appliance_query is True
+            with pytest.raises(NoSupportedProtocol):
+                self.device.refresh_status(True)
+
+    def test_refresh_status_appliance_query_failure_is_not_a_real_error(self) -> None:
+        """An appliance-query timeout, error, or skip must not count as a real error."""
+        real_cmd = MagicMock()
+        self.device._socket = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[real_cmd]),
+            patch.object(
+                self.device._socket,
+                "recv",
+                side_effect=[
+                    TimeoutError(),  # appliance query: timeout
+                    bytearray([0x0]),  # real_cmd: success
+                    bytearray([0x0]),  # real_cmd: success (appliance is SKIPped)
+                    bytearray([0x0]),  # appliance query: ResponseException
+                    bytearray([0x0]),  # real_cmd: success
+                ],
+            ),
+            patch.object(self.device, "build_send", return_value=None),
+            patch.object(
+                self.device,
+                "parse_message",
+                side_effect=[
+                    MessageResult.SUCCESS,  # real_cmd
+                    MessageResult.SUCCESS,  # real_cmd
+                    MessageResult.ERROR,  # appliance query
+                    MessageResult.SUCCESS,  # real_cmd
+                ],
+            ),
+        ):
+            assert self.device._appliance_query is True
+            self.device.refresh_status(True)  # appliance times out, ignored
+            assert "MessageQueryAppliance" in self.device._unsupported_protocol
+
+            self.device.refresh_status(True)  # appliance SKIPped, ignored
+
+            self.device._unsupported_protocol = []
+            self.device.refresh_status(True)  # appliance ResponseException, ignored
 
     def test_parse_message(self) -> None:
         """Test parse message."""


### PR DESCRIPTION
fixes #575 