### PR TITLE
fix(ac): guard XA1MessageBody parsing against short notify bodies

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -18,6 +18,8 @@ from midealocal.message import (
 
 _LOGGER = logging.getLogger(__name__)
 
+A1_MIN_BODY_LENGTH = 18
+
 BB_AC_MODES = [0, 3, 1, 2, 4, 5]
 BB_MIN_BODY_LENGTH = 21
 BB_FRESH_AIR_SWITCH_INDEX = 45
@@ -1590,9 +1592,20 @@ class MessageACResponse(MessageResponse):
             self.set_body(XA0MessageBody(super().body))
         # dataType 0x04 and messageBytes[0] 0xA1
         elif (
-            self.message_type == MessageType.notify1 and self.body_type == ListTypes.A1
+            self.message_type == MessageType.notify1
+            and self.body_type == ListTypes.A1
+            and len(super().body) >= A1_MIN_BODY_LENGTH
         ):
             self.set_body(XA1MessageBody(super().body))
+        elif (
+            self.message_type == MessageType.notify1 and self.body_type == ListTypes.A1
+        ):
+            _LOGGER.debug(
+                "Skipping notify1 A1 body too short to parse (%d < %d bytes): %s",
+                len(super().body),
+                A1_MIN_BODY_LENGTH,
+                super().body.hex(),
+            )
         # parse MessageCapabilitiesQuery/MessageCapabilitiesAdditionalQuery response
         # dataType 0x03 and messageBytes[0] 0xB5
         elif self.message_type == MessageType.query and self.body_type == ListTypes.B5:

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -5,6 +5,7 @@ import pytest
 from midealocal.const import ProtocolVersion
 from midealocal.crc8 import calculate
 from midealocal.devices.ac.message import (
+    A1_MIN_BODY_LENGTH,
     MessageA0LongQuery,
     MessageA0Query,
     MessageACBase,
@@ -796,6 +797,42 @@ class TestMessageACResponse:
         assert response.indoor_temperature == -1.3  # ((49 - 50) / 2) - 0.3 = -1.3
         assert hasattr(response, "outdoor_temperature")
         assert response.outdoor_temperature == -6.5  # ((40 - 50) / 2) - 1.5 = -6.5
+
+    def test_message_notify1_a1_short_body(self) -> None:
+        """Test Message parse notify1 A1 with a body too short to parse."""
+        self.header[9] = 0x04
+        # Real frame from a 00000Q1B / subtype 44204 unit: 7-byte body.
+        body = bytearray([0xA1, 0x00, 0x03, 0x8A, 0x95, 0xB6, 0xC1, 0x02])
+        response = MessageACResponse(self.header + body)
+
+        assert not hasattr(response, "indoor_temperature")
+        assert not hasattr(response, "outdoor_temperature")
+        assert not hasattr(response, "indoor_humidity")
+        assert not hasattr(response, "current_work_time")
+
+    def test_message_notify1_a1_body_length_boundary(self) -> None:
+        """Test Message parse notify1 A1 boundary at A1_MIN_BODY_LENGTH."""
+        self.header[9] = 0x04
+
+        # +1 accounts for the trailing checksum byte stripped by MessageResponse.
+        body = bytearray(A1_MIN_BODY_LENGTH - 1 + 1)
+        body[0] = 0xA1
+        response = MessageACResponse(self.header + body)
+        assert not hasattr(response, "indoor_temperature")
+
+        body = bytearray(A1_MIN_BODY_LENGTH + 1)
+        body[0] = 0xA1
+        body[13] = 100  # Indoor temperature byte
+        body[14] = 60  # Outdoor temperature byte
+        body[17] = 50  # Indoor humidity byte
+        response = MessageACResponse(self.header + body)
+
+        assert hasattr(response, "indoor_temperature")
+        assert response.indoor_temperature == 25.0  # (100 - 50) / 2
+        assert hasattr(response, "outdoor_temperature")
+        assert response.outdoor_temperature == 5.0  # (60 - 50) / 2
+        assert hasattr(response, "indoor_humidity")
+        assert response.indoor_humidity == 50
 
     def test_message_query_b5(self) -> None:
         """Test message query b5."""


### PR DESCRIPTION
fixes #688