### PR TITLE
fix(fa): validate mode_set_overrides values are bytes

### DIFF
--- a/midealocal/devices/fa/__init__.py
+++ b/midealocal/devices/fa/__init__.py
@@ -12,6 +12,9 @@ from .message import MessageFAResponse, MessageQuery, MessageSet
 
 _LOGGER = logging.getLogger(__name__)
 
+MIN_MODE_SET_OVERRIDE = 0x00
+MAX_MODE_SET_OVERRIDE = 0xFF
+
 
 class DeviceAttributes(StrEnum):
     """Midea FA device attributes."""
@@ -327,6 +330,30 @@ class MideaFADevice(MideaDevice):
             message.mode_set_overrides = self._mode_set_overrides
         self.build_send(message)
 
+    def _parse_mode_set_overrides(
+        self,
+        overrides: dict[str, Any],
+    ) -> dict[int, int]:
+        """Return the {mode index: body[3]} table, or {} if a value is not a byte.
+
+        Each value is written straight into the set body, so one outside 0..255
+        would raise on the bytearray assignment and lose the command.
+        """
+        parsed = {int(k): int(v) for k, v in overrides.items()}
+        out_of_range = {
+            mode: value
+            for mode, value in parsed.items()
+            if not MIN_MODE_SET_OVERRIDE <= value <= MAX_MODE_SET_OVERRIDE
+        }
+        if out_of_range:
+            _LOGGER.error(
+                "[%s] mode_set_overrides values must be 0..255, ignoring the table: %s",
+                self.device_id,
+                out_of_range,
+            )
+            return {}
+        return parsed
+
     def set_customize(self, customize: str) -> None:
         """Set customize."""
         self._speed_count = self._default_speed_count
@@ -337,10 +364,9 @@ class MideaFADevice(MideaDevice):
                 if params and "speed_count" in params:
                     self._speed_count = params.get("speed_count")
                 if params and "mode_set_overrides" in params:
-                    self._mode_set_overrides = {
-                        int(k): int(v)
-                        for k, v in params.get("mode_set_overrides").items()
-                    }
+                    self._mode_set_overrides = self._parse_mode_set_overrides(
+                        params.get("mode_set_overrides"),
+                    )
             except Exception:
                 _LOGGER.exception("[%s] Set customize error", self.device_id)
             self.update_all({"speed_count": self._speed_count})

--- a/midealocal/devices/fa/__init__.py
+++ b/midealocal/devices/fa/__init__.py
@@ -336,20 +336,30 @@ class MideaFADevice(MideaDevice):
     ) -> dict[int, int]:
         """Return the {mode index: body[3]} table, or {} if a value is not a byte.
 
-        Each value is written straight into the set body, so one outside 0..255
-        would raise on the bytearray assignment and lose the command.
+        Each value is written straight into the set body, so anything `int()`
+        would silently reshape into a byte - a fraction, a bool, a number
+        outside 0..255 - is rejected here rather than sent as some other byte
+        or raised on the bytearray assignment, losing the command.
         """
-        parsed = {int(k): int(v) for k, v in overrides.items()}
-        out_of_range = {
-            mode: value
-            for mode, value in parsed.items()
-            if not MIN_MODE_SET_OVERRIDE <= value <= MAX_MODE_SET_OVERRIDE
-        }
-        if out_of_range:
+        parsed: dict[int, int] = {}
+        rejected: dict[str, Any] = {}
+        for key, value in overrides.items():
+            if isinstance(value, bool) or (
+                isinstance(value, float) and not value.is_integer()
+            ):
+                rejected[key] = value
+                continue
+            converted = int(value)
+            if not MIN_MODE_SET_OVERRIDE <= converted <= MAX_MODE_SET_OVERRIDE:
+                rejected[key] = value
+                continue
+            parsed[int(key)] = converted
+        if rejected:
             _LOGGER.error(
-                "[%s] mode_set_overrides values must be 0..255, ignoring the table: %s",
+                "[%s] mode_set_overrides values must be whole numbers in 0..255, "
+                "ignoring the table: %s",
                 self.device_id,
-                out_of_range,
+                rejected,
             )
             return {}
         return parsed

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -518,3 +518,29 @@ class TestMideaFADevice:
 
         self.device.set_customize("{}")
         assert self.device._mode_set_overrides == {}
+
+    @pytest.mark.parametrize(
+        "customize",
+        [
+            pytest.param('{"mode_set_overrides": {"3": 256}}', id="above_a_byte"),
+            pytest.param('{"mode_set_overrides": {"3": -1}}', id="below_a_byte"),
+            pytest.param(
+                '{"mode_set_overrides": {"3": 41, "4": 256}}',
+                id="one_entry_out_of_range",
+            ),
+        ],
+    )
+    def test_set_customize_mode_set_overrides_out_of_range(
+        self,
+        customize: str,
+    ) -> None:
+        """Test an override outside 0..255 is rejected, not carried into a set."""
+        self.device.set_customize(customize)
+        assert self.device._mode_set_overrides == {}
+
+        with patch.object(self.device, "build_send") as mock_build_send:
+            self.device.set_attribute(DeviceAttributes.mode.value, "comfort")
+            mock_build_send.assert_called_once()
+            message = mock_build_send.call_args[0][0]
+            assert message.mode_set_overrides == {}
+            assert message._body[3] == 0x09

--- a/tests/devices/fa/device_fa_test.py
+++ b/tests/devices/fa/device_fa_test.py
@@ -524,17 +524,19 @@ class TestMideaFADevice:
         [
             pytest.param('{"mode_set_overrides": {"3": 256}}', id="above_a_byte"),
             pytest.param('{"mode_set_overrides": {"3": -1}}', id="below_a_byte"),
+            pytest.param('{"mode_set_overrides": {"3": 1.5}}', id="fraction"),
+            pytest.param('{"mode_set_overrides": {"3": true}}', id="bool"),
             pytest.param(
                 '{"mode_set_overrides": {"3": 41, "4": 256}}',
                 id="one_entry_out_of_range",
             ),
         ],
     )
-    def test_set_customize_mode_set_overrides_out_of_range(
+    def test_set_customize_mode_set_overrides_not_a_byte(
         self,
         customize: str,
     ) -> None:
-        """Test an override outside 0..255 is rejected, not carried into a set."""
+        """Test an override that is not a byte is rejected, not carried into a set."""
         self.device.set_customize(customize)
         assert self.device._mode_set_overrides == {}
 
@@ -544,3 +546,8 @@ class TestMideaFADevice:
             message = mock_build_send.call_args[0][0]
             assert message.mode_set_overrides == {}
             assert message._body[3] == 0x09
+
+    def test_set_customize_mode_set_overrides_integral_float(self) -> None:
+        """Test a float that is a whole number is still a usable byte."""
+        self.device.set_customize('{"mode_set_overrides": {"3": 41.0}}')
+        assert self.device._mode_set_overrides == {3: 41}


### PR DESCRIPTION
`set_customize` parses the fan mode override table added in #686 with an unvalidated `int(v)`, and the value goes straight into the set body — `_body_return[3] = override`. Two things get through that, both silent.

A value outside `0..255` raises on the bytearray assignment, inside `build_send`, so the command is lost:

```python
>>> m = MessageSet(ProtocolVersion.V1, 1)
>>> m.mode, m.mode_set_overrides = 3, {3: 256}
>>> m._body
ValueError: byte must be in range(0, 256)
```

A value `int()` merely reshapes is worse, because it succeeds: `int(1.5)` and `int(True)` are both `1`, so the fan is sent mode byte `0x01` — a mode the user never asked for, with nothing to show why.

The customize field is hand-typed (`{"mode_set_overrides": {"3": 41}}`), so both are reachable by a typo: `41` is `0x29` written in decimal, and writing the hex digits as decimal gives `291`.

This parses the table in one pass that rejects every value `int()` would reshape or refuse — a bool, a non-integral float, or a number outside `0..255` — logs the offending pairs, and drops the whole table, so the device falls back to the masked default and the set still goes out. An integral float (`41.0`) is a usable byte and is kept. Dropping the table wholesale, rather than the single bad entry, keeps the failure legible: a table that is half applied would be harder to diagnose from the device's behaviour than one that is visibly ignored.

I ran into the range half porting #686 to `wuwentao/midea-lan` (wuwentao/midea-lan#32), where review caught it; the same hole is still open here.

Verification: five parametrized cases — above a byte, below a byte, a fraction, a bool, and one bad entry in an otherwise valid table — each asserting the table is dropped *and* that the following set carries the masked default `0x09`, plus one case pinning that `41.0` still parses to `41`. Every rejection case was run against the code it guards and fails there. Full suite green locally (1606 passed), with `ruff check`, `mypy midealocal` and `pylint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
