### PR TITLE
fix(device): retry query once before marking protocol unsupported

### DIFF
--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -494,6 +494,8 @@ class MideaDevice(threading.Thread):
             result = self.parse_message(msg)
             # Prevent infinite loop
             if result == MessageResult.SUCCESS:
+                # recovery SOCKET_TIMEOUT after recv msg
+                self._socket.settimeout(SOCKET_TIMEOUT)
                 return
             if result != MessageResult.PADDING:
                 raise ResponseException
@@ -529,20 +531,19 @@ class MideaDevice(threading.Thread):
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
                     try:
-                        for attempt in range(QUERY_PROBE_RETRIES):
+                        attempt = 0
+                        while True:
                             try:
                                 self._wait_for_query_response()
                                 break
                             except TimeoutError:
+                                attempt += 1
+                                if attempt >= QUERY_PROBE_RETRIES:
+                                    raise
                                 # retry once before blacklisting: a single timeout
                                 # during the probe can be a slow device, not proof
                                 # the protocol is unsupported
-                                if attempt == QUERY_PROBE_RETRIES - 1:
-                                    raise
                                 self.build_send(cmd, query=True)
-                        # recovery SOCKET_TIMEOUT after recv msg
-                        if self._socket:
-                            self._socket.settimeout(SOCKET_TIMEOUT)
                     except TimeoutError:
                         error_count += 1
                         self._unsupported_protocol.append(cmd.__class__.__name__)

--- a/midealocal/device.py
+++ b/midealocal/device.py
@@ -36,6 +36,10 @@ SOCKET_TIMEOUT = 10  # socket connection default timeout
 QUERY_TIMEOUT = (
     5  # default is 1s, 0xAC have more queries, set to 2s, latest: increase to 5s
 )
+# A single timeout during the initial protocol probe blacklists the command for
+# the whole connection, even when it was just a slow/not-yet-ready device rather
+# than a genuinely unsupported protocol. Give it one more try before giving up on it.
+QUERY_PROBE_RETRIES = 2
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -477,6 +481,23 @@ class MideaDevice(threading.Thread):
         msg = PacketBuilder(self._device_id, data).finalize()
         self.send_message(msg, query=query)
 
+    def _wait_for_query_response(self) -> None:
+        """Wait for one query response, raising on timeout or bad data."""
+        while True:
+            if not self._socket:
+                _LOGGER.debug("[%s] device socket is none", self._device_id)
+                # raise exception to connect/main loop
+                raise SocketException
+            msg = self._socket.recv(512)
+            if len(msg) == 0:
+                raise ConnectionResetError("Connection closed by peer.")
+            result = self.parse_message(msg)
+            # Prevent infinite loop
+            if result == MessageResult.SUCCESS:
+                return
+            if result != MessageResult.PADDING:
+                raise ResponseException
+
     def refresh_status(self, check_protocol: bool = False) -> None:
         """Refresh device status."""
         cmds: list = self.build_query()
@@ -505,30 +526,23 @@ class MideaDevice(threading.Thread):
                 self.build_send(cmd, query=True)
                 # init check_protocol, skip timeout exception
                 if check_protocol:
-                    try:
-                        while True:
-                            if not self._socket:
-                                _LOGGER.debug(
-                                    "[%s] device socket is none",
-                                    self._device_id,
-                                )
-                                # raise exception to connect/main loop
-                                raise SocketException
-                            msg = self._socket.recv(512)
-                            if len(msg) == 0:
-                                raise ConnectionResetError("Connection closed by peer.")
-                            result = self.parse_message(msg)
-                            # Prevent infinite loop
-                            if result == MessageResult.SUCCESS:
-                                break
-                            elif result == MessageResult.PADDING:  # noqa: RET508
-                                continue
-                            else:
-                                raise ResponseException  # noqa: TRY301
-                        # recovery SOCKET_TIMEOUT after recv msg
-                        self._socket.settimeout(SOCKET_TIMEOUT)
                     # only catch TimoutError for check_protocol
                     # unexpected exception in recv/settimeout, catch by main loop
+                    try:
+                        for attempt in range(QUERY_PROBE_RETRIES):
+                            try:
+                                self._wait_for_query_response()
+                                break
+                            except TimeoutError:
+                                # retry once before blacklisting: a single timeout
+                                # during the probe can be a slow device, not proof
+                                # the protocol is unsupported
+                                if attempt == QUERY_PROBE_RETRIES - 1:
+                                    raise
+                                self.build_send(cmd, query=True)
+                        # recovery SOCKET_TIMEOUT after recv msg
+                        if self._socket:
+                            self._socket.settimeout(SOCKET_TIMEOUT)
                     except TimeoutError:
                         error_count += 1
                         self._unsupported_protocol.append(cmd.__class__.__name__)

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -662,7 +662,7 @@ class TestMideaDevice:
                     TimeoutError(),  # real_cmd: timeout (attempt 2, blacklisted)
                 ],
             ),
-            patch.object(self.device, "build_send", return_value=None),
+            patch.object(self.device, "build_send", return_value=None) as build_send,
             patch.object(
                 self.device,
                 "parse_message",
@@ -672,6 +672,8 @@ class TestMideaDevice:
             assert self.device._appliance_query is True
             with pytest.raises(NoSupportedProtocol):
                 self.device.refresh_status(True)
+
+        assert build_send.call_count == 3
 
     def test_refresh_status_appliance_query_failure_is_not_a_real_error(self) -> None:
         """An appliance-query timeout, error, or skip must not count as a real error."""

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -589,6 +589,7 @@ class TestMideaDevice:
                     bytearray([0x0]),
                     bytearray([0x0]),
                     TimeoutError(),
+                    TimeoutError(),
                 ],
             ),
             patch.object(self.device, "build_send", return_value=None),
@@ -620,6 +621,29 @@ class TestMideaDevice:
                 self.device.refresh_status(True)  # Timeout
             with pytest.raises(NoSupportedProtocol):
                 self.device.refresh_status(True)  # Unsupported protocol
+
+    def test_refresh_status_recovers_after_single_timeout(self) -> None:
+        """A single timeout during the probe must not blacklist the protocol."""
+        socket_mock = MagicMock()
+        with (
+            patch.object(self.device, "build_query", return_value=[]),
+            patch.object(
+                socket_mock,
+                "recv",
+                side_effect=[TimeoutError(), bytearray([0x0])],
+            ),
+            patch.object(self.device, "build_send", return_value=None) as build_send,
+            patch.object(
+                self.device,
+                "parse_message",
+                return_value=MessageResult.SUCCESS,
+            ),
+        ):
+            self.device._socket = socket_mock
+            self.device.refresh_status(True)
+
+        assert self.device._unsupported_protocol == []
+        assert build_send.call_count == 2
 
     def test_parse_message(self) -> None:
         """Test parse message."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device protocol detection to recover from temporary communication timeouts.
  * Added retry handling for transient delays during device queries.
  * Prevented supported commands from being incorrectly marked unavailable after a single timeout.
  * Improved handling of closed connections, invalid responses, and response padding.
  * Ensured device-identification responses do not mask failures in status queries.
  * Increased reliability when refreshing device status over unstable connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->