### PR TITLE
fix(b8): handle unknown error sub-codes in MessageB8GenericBody

### DIFF
--- a/midealocal/devices/b8/message.py
+++ b/midealocal/devices/b8/message.py
@@ -351,17 +351,26 @@ class MessageB8GenericBody(MessageBody):
             | B8ErrorWarningDescription
         ) = B8ErrorCanFixDescription.NO
         if self.error_type == B8ErrorType.CAN_FIX:
-            self.error_desc = B8ErrorCanFixDescription(
-                self.read_byte(body, 15 + offset),
-            )
+            try:
+                self.error_desc = B8ErrorCanFixDescription(
+                    self.read_byte(body, 15 + offset),
+                )
+            except ValueError:
+                self.error_desc = B8ErrorCanFixDescription.NO
         elif self.error_type == B8ErrorType.REBOOT:
-            self.error_desc = B8ErrorRebootDescription(
-                self.read_byte(body, 15 + offset),
-            )
+            try:
+                self.error_desc = B8ErrorRebootDescription(
+                    self.read_byte(body, 15 + offset),
+                )
+            except ValueError:
+                self.error_desc = B8ErrorRebootDescription.NO
         elif self.error_type == B8ErrorType.WARNING:
-            self.error_desc = B8ErrorWarningDescription(
-                self.read_byte(body, 15 + offset),
-            )
+            try:
+                self.error_desc = B8ErrorWarningDescription(
+                    self.read_byte(body, 15 + offset),
+                )
+            except ValueError:
+                self.error_desc = B8ErrorWarningDescription.NO
 
 
 class MessageB8WorkStatusBody(MessageB8GenericBody):

--- a/tests/devices/b8/device_b8_test.py
+++ b/tests/devices/b8/device_b8_test.py
@@ -336,6 +336,53 @@ class TestMideaB8Device:
         )
         assert self.device.attributes[DeviceAttributes.speed] == "low"
 
+    @pytest.mark.parametrize(
+        ("error_type", "error_type_name"),
+        [
+            pytest.param(B8ErrorType.CAN_FIX, "can_fix", id="can_fix"),
+            pytest.param(B8ErrorType.REBOOT, "reboot", id="reboot"),
+            pytest.param(B8ErrorType.WARNING, "warning", id="warning"),
+        ],
+    )
+    def test_query_response_unknown_error_desc(
+        self,
+        error_type: B8ErrorType,
+        error_type_name: str,
+    ) -> None:
+        """Test query response falls back to 'no' for unknown error sub-codes."""
+        header = bytearray(
+            [0xAA] + ([0x0] * 7) + [ProtocolVersion.V1] + [MessageType.query],
+        )
+        body = bytearray(
+            [
+                0x32,
+                0x1,
+                B8WorkStatus.CHARGING_WITH_WIRE,
+                B8FunctionType.NONE,
+                B8ControlType.AUTO,
+                B8Moviment.NONE,
+                B8CleanMode.AUTO,
+                B8FanLevel.NORMAL,
+                0,
+                B8WaterLevel.NORMAL,
+                40,
+                0,
+                80,
+                20,
+                0xC7,
+                error_type,
+                0xFF,  # unknown sub-code
+                B8MopState.ON,
+                0x01,
+                0x07,
+                B8Speed.HIGH,
+                0x0,  # CRC
+            ],
+        )
+        self.device.process_message(bytes(header + body))
+        assert self.device.attributes[DeviceAttributes.error_type] == error_type_name
+        assert self.device.attributes[DeviceAttributes.error_desc] == "no"
+
     def test_query_response_no_error(self) -> None:
         """Test query response."""
         header = bytearray(


### PR DESCRIPTION
Every other coded field in MessageB8GenericBody falls back on ValueError; error_desc's three enum lookups didn't, so an unrecognized error sub-code dropped the entire status update. 

Added the same try/except pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid error descriptions for `CAN_FIX`, `REBOOT`, and `WARNING` error types.
  * Invalid values now safely default to the appropriate “no error” state instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->