### PR TITLE
fix(fc): correct FCNotifyMessageBody standby bitmask check

### DIFF
--- a/midealocal/devices/fc/message.py
+++ b/midealocal/devices/fc/message.py
@@ -231,9 +231,7 @@ class FCNotifyMessageBody(MessageBody):
             self.tvoc = body[15]
         self.anion = (body[10] & 0x20 > 0) if len(body) > ANION_NOTIFY_BYTE else False
         self.standby = (
-            ((body[27] & 0xFF) == STANDBY_VALUE)
-            if len(body) > STANDBY_NOTIFY_BYTE
-            else False
+            (body[27] == STANDBY_VALUE) if len(body) > STANDBY_NOTIFY_BYTE else False
         )
         self.child_lock = (
             (body[10] & 0x10 > 0) if len(body) > CHILD_LOCK_NOTIFY_BYTE else False

--- a/midealocal/devices/fc/message.py
+++ b/midealocal/devices/fc/message.py
@@ -231,7 +231,7 @@ class FCNotifyMessageBody(MessageBody):
             self.tvoc = body[15]
         self.anion = (body[10] & 0x20 > 0) if len(body) > ANION_NOTIFY_BYTE else False
         self.standby = (
-            (body[27] & 0x14 == MAX_BYTE_VALUE)
+            ((body[27] & 0xFF) == STANDBY_VALUE)
             if len(body) > STANDBY_NOTIFY_BYTE
             else False
         )


### PR DESCRIPTION
FCNotifyMessageBody.standby had its bitmask and comparison value swapped (body[27] & 0x14 == 0xFF), making it tautologically always False. 
Fixed to match the correct sibling check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standby-state detection for FC device notifications.
  * Standby status is now reported accurately when the device sends the expected standby signal.
  * Existing handling for incomplete notification data remains unchanged, preserving safe fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->