### PR TITLE
fix(c3): use correct zone when reading temperature type

### DIFF
--- a/midealocal/devices/c3/__init__.py
+++ b/midealocal/devices/c3/__init__.py
@@ -217,7 +217,7 @@ class MideaC3Device(MideaDevice):
                         self._attributes[DeviceAttributes.room_temp_min]
                     )
             if self._attributes[DeviceAttributes.zone1_power]:
-                if self._attributes[DeviceAttributes.zone_temp_type][zone]:
+                if self._attributes[DeviceAttributes.zone_temp_type][0]:
                     self._attributes[DeviceAttributes.zone1_water_temp_mode] = True
                     self._attributes[DeviceAttributes.zone1_room_temp_mode] = False
                 else:
@@ -227,7 +227,7 @@ class MideaC3Device(MideaDevice):
                 self._attributes[DeviceAttributes.zone1_water_temp_mode] = False
                 self._attributes[DeviceAttributes.zone1_room_temp_mode] = False
             if self._attributes[DeviceAttributes.zone2_power]:
-                if self._attributes[DeviceAttributes.zone_temp_type][zone]:
+                if self._attributes[DeviceAttributes.zone_temp_type][1]:
                     self._attributes[DeviceAttributes.zone2_water_temp_mode] = True
                     self._attributes[DeviceAttributes.zone2_room_temp_mode] = False
                 else:

--- a/tests/devices/c3/device_c3_test.py
+++ b/tests/devices/c3/device_c3_test.py
@@ -182,9 +182,9 @@ class TestMideaC3Device:
             assert result[DeviceAttributes.disinfect.value] is False
             assert result[DeviceAttributes.fast_dhw.value] is True
             assert result[DeviceAttributes.zone_temp_type.value] == [True, False]
-            assert result[DeviceAttributes.zone1_room_temp_mode.value] is True
+            assert result[DeviceAttributes.zone1_room_temp_mode.value] is False
             assert result[DeviceAttributes.zone2_room_temp_mode.value] is False
-            assert result[DeviceAttributes.zone1_water_temp_mode.value] is False
+            assert result[DeviceAttributes.zone1_water_temp_mode.value] is True
             assert result[DeviceAttributes.zone2_water_temp_mode.value] is False
             assert result[DeviceAttributes.mode.value] == 2
             assert result[DeviceAttributes.mode_auto.value] == 2


### PR DESCRIPTION
process_message reuses a stale loop variable (zone leaks past for zone in [0, 1]:) to index zone_temp_type for both the zone1 and zone2 blocks — zone1 reads zone2's flag.
The existing test's assertions were written to match this behavior.
