### PR TITLE
fix(bf): align water state attribute name

### DIFF
--- a/midealocal/devices/bf/message.py
+++ b/midealocal/devices/bf/message.py
@@ -89,7 +89,7 @@ class MessageBFBody(MessageBody):
         self.child_lock = (body[32] & 0x01) > 0
         self.door = (body[32] & 0x02) > 0
         self.tank_ejected = (body[32] & 0x04) > 0
-        self.water_state = (body[32] & 0x08) > 0
+        self.water_shortage = (body[32] & 0x08) > 0
         self.water_change_reminder = (body[32] & 0x10) > 0
 
 

--- a/tests/devices/bf/device_bf_test.py
+++ b/tests/devices/bf/device_bf_test.py
@@ -70,7 +70,7 @@ class TestMideaBFDevice:
         assert self.device.attributes[DeviceAttributes.current_temperature] == 300
         assert self.device.attributes[DeviceAttributes.tank_ejected] is True
         assert self.device.attributes[DeviceAttributes.water_change_reminder] is True
-        assert self.device.attributes[DeviceAttributes.water_shortage] is None
+        assert self.device.attributes[DeviceAttributes.water_shortage] is False
         assert result[DeviceAttributes.status.value] == "working"
 
     def test_notify_response_fallback_temperature(self) -> None:


### PR DESCRIPTION
The parsed field is named water_state but DeviceAttributes declares water_shortage — the value is silently discarded since update_attributes_from_message matches by name.
Test explicitly asserts the attribute stays None.
