### PR TITLE
fix(e1): align modes,status,progress style

### DIFF
--- a/midealocal/devices/e1/__init__.py
+++ b/midealocal/devices/e1/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 from enum import StrEnum
-from typing import Any, Unpack
+from typing import Any, ClassVar, Unpack
 
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs, list_translator
@@ -52,6 +52,47 @@ class DeviceAttributes(StrEnum):
 class MideaE1Device(MideaDevice):
     """Midea E1 device."""
 
+    _modes: ClassVar[dict[int, str]] = {
+        0x00: "none",  # BYTE_MODE_NEUTRAL_GEAR
+        0x01: "auto_wash",  # BYTE_MODE_AUTO_WASH
+        0x02: "strong_wash",  # BYTE_MODE_STRONG_WASH
+        0x03: "standard_wash",  # BYTE_MODE_STANDARD_WASH
+        0x04: "eco_wash",  # BYTE_MODE_ECO_WASH
+        0x05: "glass_wash",  # BYTE_MODE_GLASS_WASH
+        0x06: "hour_wash",  # BYTE_MODE_HOUR_WASH
+        0x07: "fast_wash",  # BYTE_MODE_FAST_WASH
+        0x08: "soak_wash",  # BYTE_MODE_SOAK_WASH
+        0x09: "90min",  # BYTE_MODE_90MIN_WASH
+        0x0A: "self_clean",  # BYTE_MODE_SELF_CLEAN
+        0x0B: "fruit_wash",  # BYTE_MODE_FRUIT_WASH
+        0x0C: "self_define",  # BYTE_MODE_SELF_DEFINE
+        0x0D: "germ",  # BYTE_MODE_GERM ???
+        0x0E: "bowl_wash",  # BYTE_MODE_BOWL_WASH
+        0x0F: "kill_germ",  # BYTE_MODE_KILL_GERM
+        0x10: "sea_food_wash",  # BYTE_MODE_SEA_FOOD_WASH
+        0x12: "hot_pot_wash",  # BYTE_MODE_HOT_POT_WASH
+        0x13: "quiet_night_wash",  # BYTE_MODE_QUIET_NIGHT_WASH
+        0x14: "less_wash",  # BYTE_MODE_LESS_WASH
+        0x16: "oil_net_wash",  # BYTE_MODE_OIL_NET_WASH
+        0x19: "cloud_wash",  # BYTE_MODE_CLOUD_WASH
+    }
+    _status: ClassVar[dict[int, str]] = {
+        0x00: "off",
+        0x01: "cancel",
+        0x02: "delay",
+        0x03: "running",
+        0x04: "error",
+        0x05: "soft_gear",
+    }
+    _progress: ClassVar[list[str]] = [
+        "idle",
+        "pre_wash",
+        "wash",
+        "rinse",
+        "dry",
+        "complete",
+    ]
+
     def __init__(
         self,
         *,
@@ -89,39 +130,6 @@ class MideaE1Device(MideaDevice):
                 DeviceAttributes.bright: 0,
             },
         )
-        self._modes = {
-            0x00: "neutral_gear",  # BYTE_MODE_NEUTRAL_GEAR
-            0x01: "auto_wash",  # BYTE_MODE_AUTO_WASH
-            0x02: "strong_wash",  # BYTE_MODE_STRONG_WASH
-            0x03: "standard_wash",  # BYTE_MODE_STANDARD_WASH
-            0x04: "eco_wash",  # BYTE_MODE_ECO_WASH
-            0x05: "glass_wash",  # BYTE_MODE_GLASS_WASH
-            0x06: "hour_wash",  # BYTE_MODE_HOUR_WASH
-            0x07: "fast_wash",  # BYTE_MODE_FAST_WASH
-            0x08: "soak_wash",  # BYTE_MODE_SOAK_WASH
-            0x09: "90min",  # BYTE_MODE_90MIN_WASH
-            0x0A: "self_clean",  # BYTE_MODE_SELF_CLEAN
-            0x0B: "fruit_wash",  # BYTE_MODE_FRUIT_WASH
-            0x0C: "self_define",  # BYTE_MODE_SELF_DEFINE
-            0x0D: "germ",  # BYTE_MODE_GERM ???
-            0x0E: "bowl_wash",  # BYTE_MODE_BOWL_WASH
-            0x0F: "kill_germ",  # BYTE_MODE_KILL_GERM
-            0x10: "sea_food_wash",  # BYTE_MODE_SEA_FOOD_WASH
-            0x12: "hot_pot_wash",  # BYTE_MODE_HOT_POT_WASH
-            0x13: "quiet_night_wash",  # BYTE_MODE_QUIET_NIGHT_WASH
-            0x14: "less_wash",  # BYTE_MODE_LESS_WASH
-            0x16: "oil_net_wash",  # BYTE_MODE_OIL_NET_WASH
-            0x19: "cloud_wash",  # BYTE_MODE_CLOUD_WASH
-        }
-        self._status = {
-            0x00: "off",
-            0x01: "cancel",
-            0x02: "delay",
-            0x03: "running",
-            0x04: "error",
-            0x05: "soft_gear",
-        }
-        self._progress = ["idle", "pre_wash", "wash", "rinse", "dry", "complete"]
 
     @property
     def modes(self) -> dict[int, str]:
@@ -132,7 +140,7 @@ class MideaE1Device(MideaDevice):
         Mapping of mode codes to names.
 
         """
-        return self._modes.copy()
+        return MideaE1Device._modes.copy()
 
     def build_query(self) -> list[MessageQuery]:
         """Midea E1 device build query."""
@@ -147,7 +155,7 @@ class MideaE1Device(MideaDevice):
             If the mode code is not supported.
 
         """
-        if mode not in self._modes:
+        if mode not in MideaE1Device._modes:
             msg = f"[e1] Unsupported work mode: {mode}"
             raise ValueWrongType(msg)
 
@@ -174,7 +182,7 @@ class MideaE1Device(MideaDevice):
             raise ValueWrongType(msg)
 
         mode = next(
-            (code for code, name in self._modes.items() if name == mode_name),
+            (code for code, name in MideaE1Device._modes.items() if name == mode_name),
             None,
         )
         if mode is None or mode == 0:
@@ -189,9 +197,9 @@ class MideaE1Device(MideaDevice):
         return self.update_attributes_from_message(
             message,
             {
-                DeviceAttributes.status: self._status.get,
-                DeviceAttributes.progress: list_translator(self._progress),
-                DeviceAttributes.mode: self._modes.get,
+                DeviceAttributes.status: MideaE1Device._status.get,
+                DeviceAttributes.progress: list_translator(MideaE1Device._progress),
+                DeviceAttributes.mode: MideaE1Device._modes.get,
             },
         )
 

--- a/tests/devices/e1/device_e1_test.py
+++ b/tests/devices/e1/device_e1_test.py
@@ -75,7 +75,7 @@ class TestMideaE1Device:
         assert isinstance(message, MessageWork)
         assert message.mode == 0x04
 
-    @pytest.mark.parametrize("mode", [None, 0, "neutral_gear"])
+    @pytest.mark.parametrize("mode", [None, 0, "none"])
     def test_start_work_requires_selected_mode(self, mode: str | int | None) -> None:
         """Test starting requires a non-neutral selected mode."""
         self.device._attributes[DeviceAttributes.mode] = mode

--- a/tests/devices/e1/device_e1_test.py
+++ b/tests/devices/e1/device_e1_test.py
@@ -78,6 +78,7 @@ class TestMideaE1Device:
     @pytest.mark.parametrize("mode", [None, 0, "none"])
     def test_start_work_requires_selected_mode(self, mode: str | int | None) -> None:
         """Test starting requires a non-neutral selected mode."""
+        assert self.device.modes[0x00] == "none"
         self.device._attributes[DeviceAttributes.mode] = mode
         with pytest.raises(ValueWrongType, match="No work mode selected"):
             self.device.start_work()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default device mode label from “neutral gear” to “none,” providing clearer status information.
  - Preserved existing device behavior and message handling while improving mode interpretation consistency.
  - Improved reliability when reporting device modes and status values.

- **Tests**
  - Updated validation coverage to reflect the revised unselected-mode label.
  - Added coverage confirming the new default mode is reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->