### PR TITLE
fix(cloud): keep getToken credentials out of the debug log

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -123,8 +123,19 @@ def _mask_token(token: str) -> str:
     return visible + block * max(0, len(token) - len(visible))
 
 
+# ``"token": "..."`` / ``"key": "..."`` as they appear in a getToken response,
+# tolerating escaped quotes from ``str(bytes)`` rendering.
+_CREDENTIAL_FIELD = re.compile(
+    r'(\\?["\'](?:token|key)\\?["\']\s*:\s*\\?["\'])([^"\'\\]+)',
+    re.IGNORECASE,
+)
+
+
 def _redact_data(data: str) -> str:
     """Redact sensitive data."""
+    # Do this first: the generic patterns below only chew up parts of a token,
+    # which leaves most of the credential readable and looks redacted.
+    data = _CREDENTIAL_FIELD.sub(lambda m: m.group(1) + _mask_token(m.group(2)), data)
     patterns = [
         # Email
         r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
@@ -277,14 +288,17 @@ class MideaCloud:
                 endpoint="/v1/iot/secure/getToken",
                 data=data,
             )
+            # Log only the entry count: the payload carries token/key material.
+            tokens = (response or {}).get("tokenlist") or []
             _LOGGER.debug(
-                "Response from get_keys() for appliance_id %s with method %s: %s",
+                "get_keys() for appliance_id %s with method %s returned "
+                "%s token entries",
                 appliance_id,
                 method,
-                response,
+                len(tokens),
             )
-            if response and "tokenlist" in response:
-                for token in response["tokenlist"]:
+            if tokens:
+                for token in tokens:
                     if token["udpId"] == udp_id:
                         result[method] = {
                             "token": token["token"].lower(),

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -16,6 +16,7 @@ from midealocal.cloud import (
     MideaCloud,
     SmartHomeCloud,
     _mask_token,
+    _redact_data,
     get_default_cloud,
     get_midea_cloud,
     get_preset_account_cloud,
@@ -79,6 +80,69 @@ class CloudTest(IsolatedAsyncioTestCase):
         """Test _mask_token."""
         assert _mask_token("") == ""
         assert _mask_token("1234567890") == "12345*****"
+
+    def test_redact_data_masks_token_and_key(self) -> None:
+        """Test _redact_data masks getToken credentials.
+
+        Without an explicit rule the generic patterns only chew up the digit
+        runs inside a hex credential, which leaves most of it readable while
+        looking redacted.
+        """
+        token = "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+        key = "0011223344556677889900112233445566778899001122334455667788990011"
+        raw = str(
+            (
+                '{"code":0,"data":{"tokenlist":[{'
+                f'"udpId":"abc","token":"{token}","key":"{key}"'
+                "}]}}"
+            ).encode(),
+        )
+
+        redacted = _redact_data(raw)
+
+        # exact masked form -- the generic patterns alone produce a different,
+        # mostly-readable string, so this is what makes the test discriminating
+        assert f'"token":"{_mask_token(token)}"' in redacted
+        assert f'"key":"{_mask_token(key)}"' in redacted
+        assert token not in redacted
+        assert key not in redacted
+        # unrelated fields are untouched
+        assert '"udpId":"abc"' in redacted
+
+    def test_redact_data_handles_escaped_quotes(self) -> None:
+        """Test _redact_data masks credentials rendered with escaped quotes."""
+        token = "DEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+        redacted = _redact_data(f'{{\\"token\\": \\"{token}\\"}}')
+        assert token not in redacted
+
+    async def test_get_cloud_keys_does_not_log_credentials(self) -> None:
+        """Test get_cloud_keys keeps token material out of the debug log."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["meijucloud_get_keys1.json"],
+                self.responses["meijucloud_get_keys2.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "美的美居",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+
+        with self.assertLogs("midealocal.cloud", level="DEBUG") as logs:
+            keys = await cloud.get_cloud_keys(100)
+
+        assert keys[1]["token"] == "method1_return_token1"
+        blob = "\n".join(logs.output)
+        assert "method1_return_token1" not in blob
+        assert "method1_return_key1" not in blob
+        # the replacement line still says something useful
+        assert "token entries" in blob
 
     async def test_get_cloud_servers(self) -> None:
         """Test get cloud servers."""


### PR DESCRIPTION
Requested by @chemelli74 in wuwentao/midea-lan#44, and it also covers the
credential-logging risk CodeRabbit flagged on #717.

## Two separate leaks

**1. `_redact_data()` has no rule for `token` / `key`.**

A getToken response goes through `_api_request()`, which logs
`_redact_data(str(raw))`. None of the existing patterns target the JSON
credential fields — the only thing that touches them is the credit-card pattern
`\b(?:\d[ -]*?){13,19}\b` happening to match digit runs inside the hex value.
That produces output that *looks* redacted while leaving most of the secret
readable:

```
"token":"AABBCCDDEEFF00112**********78899AABBCCDDEEFF00112**********78899"
"key":"00112**********78899**********55667**********23344**********0011"
```

After this change:

```
"token":"AABBC***********************************************************"
"key":"00112***********************************************************"
```

The new rule runs *before* the generic patterns, so they cannot chew the value
up first, and reuses `_mask_token()` so the output matches the rest of the
module. It tolerates the escaped quotes you get from `str(bytes)` rendering.

**2. `MideaCloud.get_cloud_keys()` logs its full parsed response.**

```python
_LOGGER.debug(
    "Response from get_keys() for appliance_id %s with method %s: %s",
    appliance_id, method, response,
)
```

That is the same `tokenlist`, and unlike the `_api_request()` line it is not
passed through `_redact_data()` at all. Now logs the entry count.

## Tests

Asserting only "the raw token is absent from the redacted string" **passes
without the fix**, because the credit-card pattern already breaks the string up.
So the test asserts the exact masked form instead, and a second test drives a
real `get_cloud_keys()` call and checks no emitted record contains the token or
the key.

I verified the tests actually bite by mutating the implementation three ways:

| mutation | result |
|---|---|
| drop the `token`/`key` redaction | 3 failed |
| `get_cloud_keys()` logs `response` again | 1 failed |
| redaction rule matches `token` but not `key` | 2 failed |

`pytest ./tests/` — 1620 passed. `prek run --all-files` — clean.

Independent of #717 — this branches from `main` and touches different regions of
`cloud.py`, so the two can merge in either order. The equivalent of leak 2 is
filed upstream as wuwentao/midea-lan#45; leak 1 is present there too and I am
happy to send the same change to that repo.
