### PR TITLE
feat: expose min and max temperature for E2 and E3

### DIFF
--- a/midealocal/devices/e2/__init__.py
+++ b/midealocal/devices/e2/__init__.py
@@ -46,6 +46,8 @@ class DeviceAttributes(StrEnum):
     protection = "protection"
     current_temperature = "current_temperature"
     target_temperature = "target_temperature"
+    temperature_min = "temperature_min"
+    temperature_max = "temperature_max"
     whole_tank_heating = "whole_tank_heating"
     variable_heating = "variable_heating"
     heating_time_remaining = "heating_time_remaining"
@@ -109,6 +111,8 @@ class MideaE2Device(MideaDevice):
                 DeviceAttributes.protection: False,
                 DeviceAttributes.current_temperature: None,
                 DeviceAttributes.target_temperature: 40.0,
+                DeviceAttributes.temperature_min: 30.0,
+                DeviceAttributes.temperature_max: 75.0,
                 DeviceAttributes.whole_tank_heating: False,
                 DeviceAttributes.variable_heating: False,
                 DeviceAttributes.heating_time_remaining: 0,

--- a/midealocal/devices/e3/__init__.py
+++ b/midealocal/devices/e3/__init__.py
@@ -34,6 +34,8 @@ class DeviceAttributes(StrEnum):
     smart_volume = "smart_volume"
     current_temperature = "current_temperature"
     target_temperature = "target_temperature"
+    temperature_min = "temperature_min"
+    temperature_max = "temperature_max"
 
 
 class MideaE3Device(MideaDevice):
@@ -60,6 +62,8 @@ class MideaE3Device(MideaDevice):
                 DeviceAttributes.smart_volume: False,
                 DeviceAttributes.current_temperature: None,
                 DeviceAttributes.target_temperature: 40.0,
+                DeviceAttributes.temperature_min: 35.0,
+                DeviceAttributes.temperature_max: 65.0,
             },
         )
         self._precision_halves: bool | None = None

--- a/tests/devices/e2/device_e2_test.py
+++ b/tests/devices/e2/device_e2_test.py
@@ -99,6 +99,8 @@ class TestMideaE2Device:
         device = self._device()
         assert device.precision_halves is False
         assert device.temperature_step == 1.0
+        assert device.attributes[DeviceAttributes.temperature_max] == 75.0
+        assert device.attributes[DeviceAttributes.temperature_min] == 30.0
 
     def test_set_customize(self) -> None:
         """Test customize sets old protocol, step and precision halves."""

--- a/tests/devices/e3/device_e3_test.py
+++ b/tests/devices/e3/device_e3_test.py
@@ -61,6 +61,8 @@ class TestMideaE3Device:
         assert self.device.attributes[DeviceAttributes.smart_volume] is False
         assert self.device.attributes[DeviceAttributes.current_temperature] is None
         assert self.device.attributes[DeviceAttributes.target_temperature] == 40.0
+        assert self.device.attributes[DeviceAttributes.temperature_max] == 65.0
+        assert self.device.attributes[DeviceAttributes.temperature_min] == 35.0
         assert self.device.precision_halves is False
         assert self.device.temperature_step == 1.0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minimum and maximum temperature attributes for E2 and E3 devices.
  * E2 devices now default to a range of 30°C–75°C.
  * E3 devices now default to a range of 35°C–65°C.

* **Tests**
  * Added coverage to verify the default temperature ranges for both device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->