### PR TITLE
fix(e6): heating_modes must be named preset_modes for compatibility

### DIFF
--- a/midealocal/devices/e6/__init__.py
+++ b/midealocal/devices/e6/__init__.py
@@ -5,6 +5,8 @@ import logging
 from enum import StrEnum
 from typing import Any, ClassVar, Unpack
 
+from typing_extensions import deprecated
+
 from midealocal.const import DeviceType
 from midealocal.device import MideaDevice, MideaDeviceInitKwargs
 
@@ -34,7 +36,7 @@ class DeviceAttributes(StrEnum):
 class MideaE6Device(MideaDevice):
     """Midea E6 device."""
 
-    _heating_modes: ClassVar[list[str]] = [
+    _preset_modes: ClassVar[list[str]] = [
         "normal",
         "out",
         "home",
@@ -103,9 +105,15 @@ class MideaE6Device(MideaDevice):
             self.build_send(message)
 
     @property
+    @deprecated("Use preset_modes instead.")
     def heating_modes(self) -> list[str]:
         """Return available heating modes."""
-        return self._heating_modes
+        return self.preset_modes
+
+    @property
+    def preset_modes(self) -> list[str]:
+        """Midea E6 preset modes."""
+        return self._preset_modes
 
     def set_customize(self, customize: str) -> None:
         """Midea E2 device set customize."""

--- a/tests/devices/e6/device_e6_test.py
+++ b/tests/devices/e6/device_e6_test.py
@@ -86,6 +86,15 @@ class TestMideaE6Device:
             "sleep",
         ]
 
+    def test_preset_modes(self) -> None:
+        """Test preset_modes property returns available modes."""
+        assert self.device.preset_modes == [
+            "normal",
+            "out",
+            "home",
+            "sleep",
+        ]
+
     @pytest.mark.parametrize(
         ("attr", "value"),
         [

--- a/tests/devices/e6/device_e6_test.py
+++ b/tests/devices/e6/device_e6_test.py
@@ -79,12 +79,13 @@ class TestMideaE6Device:
 
     def test_heating_modes(self) -> None:
         """Test heating_modes property returns available modes."""
-        assert self.device.heating_modes == [
-            "normal",
-            "out",
-            "home",
-            "sleep",
-        ]
+        with pytest.warns(DeprecationWarning, match="Use preset_modes instead."):
+            assert self.device.heating_modes == [
+                "normal",
+                "out",
+                "home",
+                "sleep",
+            ]
 
     def test_preset_modes(self) -> None:
         """Test preset_modes property returns available modes."""


### PR DESCRIPTION
Water_heater uses `preset_modes` and not `heating_modes` to set in the device. This should be unified for better compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `preset_modes` property for accessing available preset heating modes.

* **Deprecation**
  * The `heating_modes` property is now deprecated and may display a warning. Use `preset_modes` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->