### PR TITLE
feat(message): add byte_mask to BodyParser

### DIFF
--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -589,6 +589,8 @@ class BodyParser[T]:
     def _get_raw_value(self, body: bytearray) -> int:
         """Get raw value from body."""
         if len(body) < self._byte + self._length_in_bytes:
+            if self._byte_mask is not None:
+                return self._default_raw_value & self._byte_mask
             return self._default_raw_value
         data = 0
         for i in range(self._length_in_bytes):

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -567,6 +567,7 @@ class BodyParser[T]:
         first_upper: bool = True,
         default_raw_value: int = 0,
         transform_func: Callable[[T], T] = lambda data: data,
+        byte_mask: int | None = None,
     ) -> None:
         """Init body parser with attribute name."""
         self.name = name
@@ -576,6 +577,7 @@ class BodyParser[T]:
         self._first_upper = first_upper
         self._default_raw_value = default_raw_value
         self._transform_func = transform_func
+        self._byte_mask = byte_mask
         if length_in_bytes < 0:
             raise ValueError("Length in bytes must be a positive value.")
         if bit is not None and (bit < 0 or bit >= length_in_bytes * 8):
@@ -598,6 +600,8 @@ class BodyParser[T]:
             data += body[byte] << (8 * i)
         if self._bit is not None:
             data = (data & (1 << self._bit)) >> self._bit
+        if self._byte_mask is not None:
+            return data & self._byte_mask
         return data
 
     def get_value(self, body: bytearray) -> T:
@@ -620,9 +624,10 @@ class BoolParser(BodyParser[bool]):
         true_value: int = 1,
         false_value: int = 0,
         default_value: bool = True,
+        byte_mask: int | None = None,
     ) -> None:
         """Init bool body parser."""
-        super().__init__(name, byte, bit)
+        super().__init__(name, byte, bit, byte_mask=byte_mask)
         self._true_value = true_value
         self._default_value = default_value
         self._false_value = false_value
@@ -644,6 +649,7 @@ class IntEnumParser[E: IntEnum](BodyParser[E]):
         length_in_bytes: int = 1,
         first_upper: bool = False,
         default_value: E | None = None,
+        byte_mask: int | None = None,
     ) -> None:
         """Init IntEnum body parser."""
         super().__init__(
@@ -651,6 +657,7 @@ class IntEnumParser[E: IntEnum](BodyParser[E]):
             byte,
             length_in_bytes=length_in_bytes,
             first_upper=first_upper,
+            byte_mask=byte_mask,
         )
         self._enum_class = enum_class
         self._default_value = default_value
@@ -678,6 +685,7 @@ class IntParser(BodyParser[int]):
         length_in_bytes: int = 1,
         first_upper: bool = False,
         transform_func: Callable[[int], int] = lambda x: x,
+        byte_mask: int | None = None,
     ) -> None:
         """Init Int body parser."""
         super().__init__(
@@ -686,6 +694,7 @@ class IntParser(BodyParser[int]):
             length_in_bytes=length_in_bytes,
             first_upper=first_upper,
             transform_func=transform_func,
+            byte_mask=byte_mask,
         )
         self._max_value = max_value
         self._min_value = min_value

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -718,6 +718,7 @@ class FloatParser(BodyParser[float]):
         first_upper: bool = True,
         default_raw_value: int = 0,
         transform_func: Callable[[float], float] = lambda data: data,
+        byte_mask: int | None = None,
     ) -> None:
         """Init Float body parser."""
         super().__init__(
@@ -727,6 +728,7 @@ class FloatParser(BodyParser[float]):
             first_upper=first_upper,
             default_raw_value=default_raw_value,
             transform_func=transform_func,
+            byte_mask=byte_mask,
         )
 
     def _parse(self, raw_value: int) -> float:

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -100,6 +100,46 @@ class TestBodyParser:
             value = parser._get_raw_value(self.body)
             assert value == (1 if i in [0, 2, 10] else 0)
 
+    @pytest.mark.parametrize(
+        ("value", "mask", "expected_value"),
+        [
+            pytest.param(0b00000000, 0b00001111, 0b00000000, id="0x00_with_0x0F"),
+            pytest.param(0b00000001, 0b00001111, 0b00000001, id="0x01_with_0x0F"),
+            pytest.param(0b00000011, 0b00001111, 0b00000011, id="0x03_with_0x0F"),
+            pytest.param(0b00000111, 0b00001111, 0b00000111, id="0x07_with_0x0F"),
+            pytest.param(0b00001111, 0b00001111, 0b00001111, id="0x0F_with_0x0F"),
+            pytest.param(0b00011111, 0b00001111, 0b00001111, id="0x1F_with_0x0F"),
+            pytest.param(0b00111111, 0b00001111, 0b00001111, id="0x3F_with_0x0F"),
+            pytest.param(0b01111111, 0b00001111, 0b00001111, id="0x7F_with_0x0F"),
+            pytest.param(0b11111111, 0b00001111, 0b00001111, id="0xFF_with_0x0F"),
+        ],
+    )
+    def test_get_raw_data_byte_mask(
+        self,
+        value: int,
+        mask: int,
+        expected_value: int,
+    ) -> None:
+        """Test get raw value with byte_mask."""
+        parser = BodyParser[int]("name", 0, length_in_bytes=2, byte_mask=mask)
+        assert parser._get_raw_value(bytearray([0xFF, value])) == expected_value
+
+    def test_get_raw_data_with_0_byte_mask(
+        self,
+    ) -> None:
+        """Test get raw value with 0 byte_mask."""
+        parser = BodyParser[int]("name", 0, length_in_bytes=2, byte_mask=0x00)
+        for i in range(255):
+            assert parser._get_raw_value(bytearray([0xFF, i])) == 0
+
+    def test_get_raw_data_with_255_byte_mask(
+        self,
+    ) -> None:
+        """Test get raw value with 255 byte_mask."""
+        parser = BodyParser[int]("name", 0, length_in_bytes=2, byte_mask=0xFF)
+        for i in range(255):
+            assert parser._get_raw_value(bytearray([0xFF, i])) == i
+
     def test_parse_unimplemented(self) -> None:
         """Test parse unimplemented."""
         parser = BodyParser[int]("name", 4, length_in_bytes=2, bit=2)
@@ -178,6 +218,12 @@ class TestIntParser:
                 assert parser._parse(i) == 255
             else:
                 assert parser._parse(i) == i
+
+    def test_int_byte_mask(self) -> None:
+        """Test int parse with byte_mask."""
+        parser = IntParser("name", 0, byte_mask=0x7F)
+        for i in range(255):
+            assert parser._get_raw_value(bytearray([i])) == (i & 0x7F)
 
 
 class TestFloatParser:

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -87,6 +87,12 @@ class TestBodyParser:
         value = parser._get_raw_value(self.body)
         assert value == 0
 
+    def test_get_raw_out_of_bounds_with_byte_mask(self) -> None:
+        """Test get raw value out of bounds with byte_mask."""
+        parser = BodyParser[int]("name", 6, default_raw_value=0xFF, byte_mask=0x07)
+        value = parser._get_raw_value(self.body)
+        assert value == 0x07
+
     def test_get_raw_data_size_out_of_bounds(self) -> None:
         """Test get raw value out of bounds."""
         parser = BodyParser[int]("name", 5, length_in_bytes=2)

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -135,7 +135,7 @@ class TestBodyParser:
     ) -> None:
         """Test get raw value with 0 byte_mask."""
         parser = BodyParser[int]("name", 0, length_in_bytes=2, byte_mask=0x00)
-        for i in range(255):
+        for i in range(256):
             assert parser._get_raw_value(bytearray([0xFF, i])) == 0
 
     def test_get_raw_data_with_255_byte_mask(
@@ -143,7 +143,7 @@ class TestBodyParser:
     ) -> None:
         """Test get raw value with 255 byte_mask."""
         parser = BodyParser[int]("name", 0, length_in_bytes=2, byte_mask=0xFF)
-        for i in range(255):
+        for i in range(256):
             assert parser._get_raw_value(bytearray([0xFF, i])) == i
 
     def test_parse_unimplemented(self) -> None:
@@ -228,7 +228,7 @@ class TestIntParser:
     def test_int_byte_mask(self) -> None:
         """Test int parse with byte_mask."""
         parser = IntParser("name", 0, byte_mask=0x7F)
-        for i in range(255):
+        for i in range(256):
             assert parser._get_raw_value(bytearray([i])) == (i & 0x7F)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional byte-mask support for boolean, integer, enum, floating-point, and general message value parsing.
  * Parsed values can now selectively use specific bits from incoming data.
  * Default values used when message data is incomplete are also masked consistently.

* **Tests**
  * Added coverage confirming masked values behave correctly, including zero, full-byte, and partial masks.
  * Added validation for masked integer parsing and out-of-bounds message data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->