### PR TITLE
feat(ac): add group 3 outdoor fan speed

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -18,6 +18,7 @@ from .message import (
     MessageGeneralSet,
     MessageGroupOneQuery,
     MessageGroupSevenQuery,
+    MessageGroupThreeQuery,
     MessageGroupTwoQuery,
     MessageGroupZeroQuery,
     MessageHumidityQuery,
@@ -45,6 +46,7 @@ ACQuery = (
     | MessageHumidityQuery
     | MessageGroupZeroQuery
     | MessageGroupOneQuery
+    | MessageGroupThreeQuery
     | MessageGroupTwoQuery
     | MessageGroupSevenQuery
     | MessageCapabilitiesQuery
@@ -124,6 +126,8 @@ class DeviceAttributes(StrEnum):
     indoor_fan_speed = "indoor_fan_speed"
     target_indoor_fan_speed = "target_indoor_fan_speed"
     water_pump_running = "water_pump_running"
+    # group 3: outdoor fan
+    outdoor_fan_speed_raw = "outdoor_fan_speed_raw"
     # group 7: real time compressor power
     compressor_power = "compressor_power"
 
@@ -301,6 +305,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.indoor_fan_speed: None,
                 DeviceAttributes.target_indoor_fan_speed: None,
                 DeviceAttributes.water_pump_running: None,
+                DeviceAttributes.outdoor_fan_speed_raw: None,
                 DeviceAttributes.compressor_power: None,
             },
         )
@@ -398,6 +403,7 @@ class MideaACDevice(MideaDevice):
             # initial protocol check and the query is skipped from then on.
             MessageGroupOneQuery(self._message_protocol_version),
             MessageGroupTwoQuery(self._message_protocol_version),
+            MessageGroupThreeQuery(self._message_protocol_version),
             MessageGroupSevenQuery(self._message_protocol_version),
             MessageCapabilitiesQuery(self._message_protocol_version),
             MessageCapabilitiesAdditionalQuery(self._message_protocol_version),
@@ -855,6 +861,7 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.indoor_fan_speed,
             DeviceAttributes.target_indoor_fan_speed,
             DeviceAttributes.water_pump_running,
+            DeviceAttributes.outdoor_fan_speed_raw,
             DeviceAttributes.compressor_power,
         ]:
             if attr == DeviceAttributes.prompt_tone:

--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -127,7 +127,7 @@ class DeviceAttributes(StrEnum):
     target_indoor_fan_speed = "target_indoor_fan_speed"
     water_pump_running = "water_pump_running"
     # group 3: outdoor fan
-    outdoor_fan_speed_raw = "outdoor_fan_speed_raw"
+    outdoor_fan_speed = "outdoor_fan_speed"
     # group 7: real time compressor power
     compressor_power = "compressor_power"
 
@@ -305,7 +305,7 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.indoor_fan_speed: None,
                 DeviceAttributes.target_indoor_fan_speed: None,
                 DeviceAttributes.water_pump_running: None,
-                DeviceAttributes.outdoor_fan_speed_raw: None,
+                DeviceAttributes.outdoor_fan_speed: None,
                 DeviceAttributes.compressor_power: None,
             },
         )
@@ -861,7 +861,7 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.indoor_fan_speed,
             DeviceAttributes.target_indoor_fan_speed,
             DeviceAttributes.water_pump_running,
-            DeviceAttributes.outdoor_fan_speed_raw,
+            DeviceAttributes.outdoor_fan_speed,
             DeviceAttributes.compressor_power,
         ]:
             if attr == DeviceAttributes.prompt_tone:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -51,9 +51,11 @@ SUB_PROTOCOL_BODY_TEMP_CHECK = 0x80
 TEMP_DECIMAL_MIN_BODY_LENGTH = 20
 TIMER_MIN_SUBPROTOCOL_LENGTH = 27
 XBB_SN8_BYTE_FLAG = 0x31
+XC1_SUBBODY_TYPE_03 = 0x03
 XC1_SUBBODY_TYPE_40 = 0x40
 XC1_SUBBODY_TYPE_41 = 0x41
 XC1_SUBBODY_TYPE_42 = 0x42
+XC1_SUBBODY_TYPE_43 = 0x43
 XC1_SUBBODY_TYPE_44 = 0x44
 XC1_SUBBODY_TYPE_45 = 0x45
 XC1_SUBBODY_TYPE_47 = 0x47
@@ -64,9 +66,11 @@ XC1_OPERATING_TIME_MIN_LENGTH = 19
 
 # Group data query: the third payload byte selects the group, 0x40 | group number.
 XC1_GROUP_QUERY_BASE = 0x40
+XC1_GROUP_THREE_SPEED_OFFSET = 10
 # Minimum body length required to parse each group data response.
 XC1_GROUP_ONE_MIN_LENGTH = 15
 XC1_GROUP_TWO_MIN_LENGTH = 9
+XC1_GROUP_THREE_MIN_LENGTH = XC1_GROUP_THREE_SPEED_OFFSET + 1
 XC1_GROUP_SEVEN_MIN_LENGTH = 12
 # Refrigerant circuit temperatures are reported as half degrees with an offset:
 # T1/T2 (indoor ambient / indoor coil) use 30, T3/T4 (outdoor coil / ambient) use 50.
@@ -380,6 +384,12 @@ class MessageGroupTwoQuery(MessageGroupDataQuery):
     """AC message indoor fan query(queryType == "group_data_two")."""
 
     _group = 2
+
+
+class MessageGroupThreeQuery(MessageGroupDataQuery):
+    """AC message outdoor fan query(queryType == "group_data_three")."""
+
+    _group = 3
 
 
 class MessagePowerQuery(MessageGroupDataQuery):
@@ -1357,6 +1367,10 @@ class XC1MessageBody(MessageBody):
             self._parse_group_one(body)
         elif group_type == XC1_SUBBODY_TYPE_42:
             self._parse_group_two(body)
+        elif group_type in (XC1_SUBBODY_TYPE_03, XC1_SUBBODY_TYPE_43):
+            # Midea references select group 3 by the low nibble; the tested
+            # device answered a 0x43 query with 0x03 here.
+            self._parse_group_three(body)
         elif group_type == XC1_SUBBODY_TYPE_47:
             self._parse_group_seven(body)
         elif group_type == XC1_SUBBODY_TYPE_40:
@@ -1439,6 +1453,15 @@ class XC1MessageBody(MessageBody):
         self.indoor_fan_speed = body[5] * XC1_FAN_SPEED_FACTOR
         # Could also be the float switch (tank full) that triggers the pump.
         self.water_pump_running = bool(body[8] & XC1_WATER_PUMP_MASK)
+
+    def _parse_group_three(self, body: bytearray) -> None:
+        """Parse group 3 data: outdoor fan speed."""
+        if len(body) < XC1_GROUP_THREE_MIN_LENGTH:
+            return
+        # Midea plugin references decode this byte as current outdoor fan speed
+        # using raw * 8. The tested unit's engineer display instead labels the
+        # matching raw byte as set speed, so preserve the unscaled value.
+        self.outdoor_fan_speed_raw = body[XC1_GROUP_THREE_SPEED_OFFSET]
 
     def _parse_group_seven(self, body: bytearray) -> None:
         """Parse group 7 data: real time compressor power."""

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -70,7 +70,6 @@ XC1_GROUP_THREE_SPEED_OFFSET = 10
 # Minimum body length required to parse each group data response.
 XC1_GROUP_ONE_MIN_LENGTH = 15
 XC1_GROUP_TWO_MIN_LENGTH = 9
-XC1_GROUP_THREE_MIN_LENGTH = XC1_GROUP_THREE_SPEED_OFFSET + 1
 XC1_GROUP_SEVEN_MIN_LENGTH = 12
 # Refrigerant circuit temperatures are reported as half degrees with an offset:
 # T1/T2 (indoor ambient / indoor coil) use 30, T3/T4 (outdoor coil / ambient) use 50.
@@ -1456,12 +1455,12 @@ class XC1MessageBody(MessageBody):
 
     def _parse_group_three(self, body: bytearray) -> None:
         """Parse group 3 data: outdoor fan speed."""
-        if len(body) < XC1_GROUP_THREE_MIN_LENGTH:
-            return
         # Midea plugin references decode this byte as current outdoor fan speed
-        # using raw * 8. The tested unit's engineer display instead labels the
-        # matching raw byte as set speed, so preserve the unscaled value.
-        self.outdoor_fan_speed_raw = body[XC1_GROUP_THREE_SPEED_OFFSET]
+        # in units of 8 RPM. The engineer display labels the matching raw byte
+        # as set speed, but group 5 exposes that target separately.
+        self.outdoor_fan_speed = (
+            self.read_byte(body, XC1_GROUP_THREE_SPEED_OFFSET) * XC1_FAN_SPEED_FACTOR
+        )
 
     def _parse_group_seven(self, body: bytearray) -> None:
         """Parse group 7 data: real time compressor power."""

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -697,7 +697,7 @@ class TestMideaACDevice:
             mock_message.target_indoor_fan_speed = 416
             mock_message.water_pump_running = False
             # group 3
-            mock_message.outdoor_fan_speed_raw = 106
+            mock_message.outdoor_fan_speed = 848
             # group 7
             mock_message.compressor_power = 269
 
@@ -715,7 +715,7 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.indoor_fan_speed.value] == 424
             assert result[DeviceAttributes.target_indoor_fan_speed.value] == 416
             assert result[DeviceAttributes.water_pump_running.value] is False
-            assert result[DeviceAttributes.outdoor_fan_speed_raw.value] == 106
+            assert result[DeviceAttributes.outdoor_fan_speed.value] == 848
             assert result[DeviceAttributes.compressor_power.value] == 269
 
     def test_set_attribute_group_data_is_read_only(self) -> None:
@@ -734,7 +734,7 @@ class TestMideaACDevice:
                 DeviceAttributes.indoor_fan_speed,
                 DeviceAttributes.target_indoor_fan_speed,
                 DeviceAttributes.water_pump_running,
-                DeviceAttributes.outdoor_fan_speed_raw,
+                DeviceAttributes.outdoor_fan_speed,
                 DeviceAttributes.compressor_power,
             ]:
                 self.device.set_attribute(attr.value, 1)

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -12,6 +12,7 @@ from midealocal.devices.ac.message import (
     MessageCapabilitiesQuery,
     MessageGroupOneQuery,
     MessageGroupSevenQuery,
+    MessageGroupThreeQuery,
     MessageGroupTwoQuery,
     MessageGroupZeroQuery,
     MessageHumidityQuery,
@@ -311,7 +312,7 @@ class TestMideaACDevice:
 
         self.device._used_subprotocol = False
         queries = self.device.build_query()
-        assert len(queries) == 11
+        assert len(queries) == 12
         assert isinstance(queries[0], MessageQuery)
         assert isinstance(queries[1], MessageNewProtocolQuery)
         assert isinstance(queries[2], MessageNewProtocolSelfCleanQuery)
@@ -320,9 +321,10 @@ class TestMideaACDevice:
         assert isinstance(queries[5], MessageGroupZeroQuery)
         assert isinstance(queries[6], MessageGroupOneQuery)
         assert isinstance(queries[7], MessageGroupTwoQuery)
-        assert isinstance(queries[8], MessageGroupSevenQuery)
-        assert isinstance(queries[9], MessageCapabilitiesQuery)
-        assert isinstance(queries[10], MessageCapabilitiesAdditionalQuery)
+        assert isinstance(queries[8], MessageGroupThreeQuery)
+        assert isinstance(queries[9], MessageGroupSevenQuery)
+        assert isinstance(queries[10], MessageCapabilitiesQuery)
+        assert isinstance(queries[11], MessageCapabilitiesAdditionalQuery)
 
     def test_build_query_omits_rate_select_until_capability_confirmed(self) -> None:
         """Test rate_select stays out of the B1 query until b5_electricity confirms it.
@@ -694,6 +696,8 @@ class TestMideaACDevice:
             mock_message.indoor_fan_speed = 424
             mock_message.target_indoor_fan_speed = 416
             mock_message.water_pump_running = False
+            # group 3
+            mock_message.outdoor_fan_speed_raw = 106
             # group 7
             mock_message.compressor_power = 269
 
@@ -711,6 +715,7 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.indoor_fan_speed.value] == 424
             assert result[DeviceAttributes.target_indoor_fan_speed.value] == 416
             assert result[DeviceAttributes.water_pump_running.value] is False
+            assert result[DeviceAttributes.outdoor_fan_speed_raw.value] == 106
             assert result[DeviceAttributes.compressor_power.value] == 269
 
     def test_set_attribute_group_data_is_read_only(self) -> None:
@@ -729,6 +734,7 @@ class TestMideaACDevice:
                 DeviceAttributes.indoor_fan_speed,
                 DeviceAttributes.target_indoor_fan_speed,
                 DeviceAttributes.water_pump_running,
+                DeviceAttributes.outdoor_fan_speed_raw,
                 DeviceAttributes.compressor_power,
             ]:
                 self.device.set_attribute(attr.value, 1)

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -15,6 +15,7 @@ from midealocal.devices.ac.message import (
     MessageGroupDataQuery,
     MessageGroupOneQuery,
     MessageGroupSevenQuery,
+    MessageGroupThreeQuery,
     MessageGroupTwoQuery,
     MessageGroupZeroQuery,
     MessageHumidityQuery,
@@ -161,6 +162,7 @@ class TestMessageGroupDataQuery:
             (MessageGroupZeroQuery, 0),
             (MessageGroupOneQuery, 1),
             (MessageGroupTwoQuery, 2),
+            (MessageGroupThreeQuery, 3),
             (MessagePowerQuery, 4),
             (MessageHumidityQuery, 5),
             (MessageGroupSevenQuery, 7),
@@ -1517,6 +1519,29 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
         assert not hasattr(response, "indoor_fan_speed")
         assert not hasattr(response, "water_pump_running")
+
+    @pytest.mark.parametrize("group_discriminator", [0x03, 0x43])
+    def test_message_query_c1_group_three(self, group_discriminator: int) -> None:
+        """Test group 3 response with outdoor fan raw speed data."""
+        self.header[9] = 0x03
+        body = bytearray(20)
+        body[0] = 0xC1  # Body type
+        body[3] = group_discriminator
+        body[10] = 106  # Matches engineer display; physical scaling remains raw.
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "outdoor_fan_speed_raw")
+        assert response.outdoor_fan_speed_raw == 106
+
+    def test_message_query_c1_0x03_short_body(self) -> None:
+        """Test Message parse group 3 response with a truncated body."""
+        self.header[9] = 0x03
+        body = bytearray(10)
+        body[0] = 0xC1  # Body type
+        body[3] = 0x03  # group 3 response discriminator
+
+        response = MessageACResponse(self.header + body)
+        assert not hasattr(response, "outdoor_fan_speed_raw")
 
     def test_message_query_c1_0x47(self) -> None:
         """Test Message parse query C1 0x47, compressor power group data."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1527,21 +1527,22 @@ class TestMessageACResponse:
         body = bytearray(20)
         body[0] = 0xC1  # Body type
         body[3] = group_discriminator
-        body[10] = 106  # Matches engineer display; physical scaling remains raw.
+        body[10] = 106  # Current outdoor fan speed: 106 * 8 = 848 RPM.
 
         response = MessageACResponse(self.header + body)
-        assert hasattr(response, "outdoor_fan_speed_raw")
-        assert response.outdoor_fan_speed_raw == 106
+        assert hasattr(response, "outdoor_fan_speed")
+        assert response.outdoor_fan_speed == 848
 
     def test_message_query_c1_0x03_short_body(self) -> None:
-        """Test Message parse group 3 response with a truncated body."""
+        """Test a truncated group 3 response defaults fan speed to zero."""
         self.header[9] = 0x03
         body = bytearray(10)
         body[0] = 0xC1  # Body type
         body[3] = 0x03  # group 3 response discriminator
 
         response = MessageACResponse(self.header + body)
-        assert not hasattr(response, "outdoor_fan_speed_raw")
+        assert hasattr(response, "outdoor_fan_speed")
+        assert response.outdoor_fan_speed == 0
 
     def test_message_query_c1_0x47(self) -> None:
         """Test Message parse query C1 0x47, compressor power group data."""


### PR DESCRIPTION
## Summary

- add the AC group 3 query
- expose decoded `outdoor_fan_speed` as read-only telemetry
- accept both `0x03` and `0x43` group 3 response discriminators
- add query, parsing, truncation, attribute-storage, and read-only tests

Related to #424.

## Protocol evidence

Tested on a Midea MFAG70VB-N / MFAG70VB-W, device type `0xAC`, protocol v3.

Group 3 request body:

`41 21 01 43 00 01 73`

An observed response body was:

`c1 21 01 03 00 00 00 00 00 08 6a 00 72 b3 92 00 16 ...`

The tested device returned response discriminator `0x03`, and body offset 10 contains `0x6a` (`106`). A bundled Midea AC plugin in `midea-msmart` selects group 3 by the low nibble, so the parser accepts both `0x03` and `0x43`.

Engineer channel 12, documented as outdoor-fan set speed, matched body offset 10 across these observations:

| Engineer display | Group 3 body offset 10 |
|---:|---:|
| 0 | 0 |
| 39 | 39 |
| 105 | 105–106 during transition |
| 106 | 106 |

The bundled plugin describes the same byte as current outdoor-fan speed and decodes it with a `raw * 8` scale. Following maintainer review, this change uses that current-speed interpretation and exposes the decoded value as `outdoor_fan_speed`. Group 5 exposes its separate target as `target_outdoor_fan_speed`.

Reference: https://github.com/mill1000/midea-msmart/blob/04cdb96fbcbccdf75fe0772503c3bb772ff6af89/reference/0xAC/T0xAC_3.5.260526.zip

## Compatibility

Group 3 uses its own query class, so devices that do not answer it can have that query excluded by the existing unsupported-protocol detection. Short responses are handled through the existing `read_byte()` default.

## Validation

- `python -m pytest ./tests/` — 1,652 passed
- `prek run --all-files` — all checks passed

Implementation and pull-request description written with OpenAI Codex (GPT-5.6-Sol).
