### PR TITLE
feat(ac): expose group 5 targets and defrost stage

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -124,6 +124,10 @@ class DeviceAttributes(StrEnum):
     indoor_fan_speed = "indoor_fan_speed"
     target_indoor_fan_speed = "target_indoor_fan_speed"
     water_pump_running = "water_pump_running"
+    # group 5: outdoor-unit targets and defrost state
+    target_outdoor_fan_speed = "target_outdoor_fan_speed"
+    target_expansion_valve_angle = "target_expansion_valve_angle"
+    defrost_stage = "defrost_stage"
     # group 7: real time compressor power
     compressor_power = "compressor_power"
 
@@ -301,6 +305,9 @@ class MideaACDevice(MideaDevice):
                 DeviceAttributes.indoor_fan_speed: None,
                 DeviceAttributes.target_indoor_fan_speed: None,
                 DeviceAttributes.water_pump_running: None,
+                DeviceAttributes.target_outdoor_fan_speed: None,
+                DeviceAttributes.target_expansion_valve_angle: None,
+                DeviceAttributes.defrost_stage: None,
                 DeviceAttributes.compressor_power: None,
             },
         )
@@ -855,6 +862,9 @@ class MideaACDevice(MideaDevice):
             DeviceAttributes.indoor_fan_speed,
             DeviceAttributes.target_indoor_fan_speed,
             DeviceAttributes.water_pump_running,
+            DeviceAttributes.target_outdoor_fan_speed,
+            DeviceAttributes.target_expansion_valve_angle,
+            DeviceAttributes.defrost_stage,
             DeviceAttributes.compressor_power,
         ]:
             if attr == DeviceAttributes.prompt_tone:

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -60,11 +60,13 @@ XC1_SUBBODY_TYPE_47 = 0x47
 XC1_SUBBODY_TYPE_INDEX = 3
 XC1_HUMIDITY_INDEX = 4
 XC1_CONSUMPTION_MIN_LENGTH = 19
-XC1_GROUP_FIVE_DIAGNOSTICS_MIN_LENGTH = 11
 XC1_OPERATING_TIME_MIN_LENGTH = 19
 
 # Group data query: the third payload byte selects the group, 0x40 | group number.
 XC1_GROUP_QUERY_BASE = 0x40
+XC1_GROUP_FIVE_TARGET_OUTDOOR_FAN_SPEED_INDEX = 8
+XC1_GROUP_FIVE_TARGET_EXPANSION_VALVE_ANGLE_INDEX = 9
+XC1_GROUP_FIVE_DEFROST_STAGE_INDEX = 10
 # Minimum body length required to parse each group data response.
 XC1_GROUP_ONE_MIN_LENGTH = 15
 XC1_GROUP_TWO_MIN_LENGTH = 9
@@ -1440,15 +1442,20 @@ class XC1MessageBody(MessageBody):
 
     def _parse_group_five(self, body: bytearray) -> None:
         """Parse group 5 data: humidity and outdoor-unit targets."""
-        if len(body) <= XC1_HUMIDITY_INDEX:
-            return
         # Indoor humidity should match the XBB/XA1 message when available.
-        self.indoor_humidity = body[XC1_HUMIDITY_INDEX] or None
-        if len(body) < XC1_GROUP_FIVE_DIAGNOSTICS_MIN_LENGTH:
-            return
-        self.target_outdoor_fan_speed = body[8] * XC1_FAN_SPEED_FACTOR
-        self.target_expansion_valve_angle = body[9] * XC1_FAN_SPEED_FACTOR
-        self.defrost_stage = body[10]
+        self.indoor_humidity = self.read_byte(body, XC1_HUMIDITY_INDEX) or None
+        self.target_outdoor_fan_speed = (
+            self.read_byte(body, XC1_GROUP_FIVE_TARGET_OUTDOOR_FAN_SPEED_INDEX)
+            * XC1_FAN_SPEED_FACTOR
+        )
+        self.target_expansion_valve_angle = (
+            self.read_byte(body, XC1_GROUP_FIVE_TARGET_EXPANSION_VALVE_ANGLE_INDEX)
+            * XC1_FAN_SPEED_FACTOR
+        )
+        self.defrost_stage = self.read_byte(
+            body,
+            XC1_GROUP_FIVE_DEFROST_STAGE_INDEX,
+        )
 
     def _parse_group_seven(self, body: bytearray) -> None:
         """Parse group 7 data: real time compressor power."""

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -60,6 +60,7 @@ XC1_SUBBODY_TYPE_47 = 0x47
 XC1_SUBBODY_TYPE_INDEX = 3
 XC1_HUMIDITY_INDEX = 4
 XC1_CONSUMPTION_MIN_LENGTH = 19
+XC1_GROUP_FIVE_DIAGNOSTICS_MIN_LENGTH = 11
 XC1_OPERATING_TIME_MIN_LENGTH = 19
 
 # Group data query: the third payload byte selects the group, 0x40 | group number.
@@ -1396,10 +1397,7 @@ class XC1MessageBody(MessageBody):
                 + (self.current_operating_time_second / 3600)
             )
         elif group_type == XC1_SUBBODY_TYPE_45:
-            if len(body) <= XC1_HUMIDITY_INDEX:
-                return
-            # indoor humidity, it should be the same value as XBB/XA1 message
-            self.indoor_humidity = body[4] if body[4] != 0 else None
+            self._parse_group_five(body)
 
     def _parse_group_one(self, body: bytearray) -> None:
         """Parse group 1 data: compressor and refrigerant circuit.
@@ -1439,6 +1437,18 @@ class XC1MessageBody(MessageBody):
         self.indoor_fan_speed = body[5] * XC1_FAN_SPEED_FACTOR
         # Could also be the float switch (tank full) that triggers the pump.
         self.water_pump_running = bool(body[8] & XC1_WATER_PUMP_MASK)
+
+    def _parse_group_five(self, body: bytearray) -> None:
+        """Parse group 5 data: humidity and outdoor-unit targets."""
+        if len(body) <= XC1_HUMIDITY_INDEX:
+            return
+        # Indoor humidity should match the XBB/XA1 message when available.
+        self.indoor_humidity = body[XC1_HUMIDITY_INDEX] or None
+        if len(body) < XC1_GROUP_FIVE_DIAGNOSTICS_MIN_LENGTH:
+            return
+        self.target_outdoor_fan_speed = body[8] * XC1_FAN_SPEED_FACTOR
+        self.target_expansion_valve_angle = body[9] * XC1_FAN_SPEED_FACTOR
+        self.defrost_stage = body[10]
 
     def _parse_group_seven(self, body: bytearray) -> None:
         """Parse group 7 data: real time compressor power."""

--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -1443,19 +1443,26 @@ class XC1MessageBody(MessageBody):
     def _parse_group_five(self, body: bytearray) -> None:
         """Parse group 5 data: humidity and outdoor-unit targets."""
         # Indoor humidity should match the XBB/XA1 message when available.
-        self.indoor_humidity = self.read_byte(body, XC1_HUMIDITY_INDEX) or None
-        self.target_outdoor_fan_speed = (
-            self.read_byte(body, XC1_GROUP_FIVE_TARGET_OUTDOOR_FAN_SPEED_INDEX)
-            * XC1_FAN_SPEED_FACTOR
-        )
-        self.target_expansion_valve_angle = (
-            self.read_byte(body, XC1_GROUP_FIVE_TARGET_EXPANSION_VALVE_ANGLE_INDEX)
-            * XC1_FAN_SPEED_FACTOR
-        )
-        self.defrost_stage = self.read_byte(
-            body,
-            XC1_GROUP_FIVE_DEFROST_STAGE_INDEX,
-        )
+        if len(body) > XC1_HUMIDITY_INDEX:
+            self.indoor_humidity = self.read_byte(body, XC1_HUMIDITY_INDEX) or None
+        if len(body) > XC1_GROUP_FIVE_TARGET_OUTDOOR_FAN_SPEED_INDEX:
+            self.target_outdoor_fan_speed = (
+                self.read_byte(body, XC1_GROUP_FIVE_TARGET_OUTDOOR_FAN_SPEED_INDEX)
+                * XC1_FAN_SPEED_FACTOR
+            )
+        if len(body) > XC1_GROUP_FIVE_TARGET_EXPANSION_VALVE_ANGLE_INDEX:
+            self.target_expansion_valve_angle = (
+                self.read_byte(
+                    body,
+                    XC1_GROUP_FIVE_TARGET_EXPANSION_VALVE_ANGLE_INDEX,
+                )
+                * XC1_FAN_SPEED_FACTOR
+            )
+        if len(body) > XC1_GROUP_FIVE_DEFROST_STAGE_INDEX:
+            self.defrost_stage = self.read_byte(
+                body,
+                XC1_GROUP_FIVE_DEFROST_STAGE_INDEX,
+            )
 
     def _parse_group_seven(self, body: bytearray) -> None:
         """Parse group 7 data: real time compressor power."""

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -670,7 +670,7 @@ class TestMideaACDevice:
             assert not self.device.attributes[DeviceAttributes.screen_display]
 
     def test_process_message_group_data(self) -> None:
-        """Test that group 1/2/7 data is stored in the device attributes."""
+        """Test that group 1/2/5/7 data is stored in the device attributes."""
         with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
             mock_message = mock_message_response.return_value
             mock_message.used_subprotocol = False
@@ -694,6 +694,10 @@ class TestMideaACDevice:
             mock_message.indoor_fan_speed = 424
             mock_message.target_indoor_fan_speed = 416
             mock_message.water_pump_running = False
+            # group 5
+            mock_message.target_outdoor_fan_speed = 600
+            mock_message.target_expansion_valve_angle = 248
+            mock_message.defrost_stage = 2
             # group 7
             mock_message.compressor_power = 269
 
@@ -711,6 +715,9 @@ class TestMideaACDevice:
             assert result[DeviceAttributes.indoor_fan_speed.value] == 424
             assert result[DeviceAttributes.target_indoor_fan_speed.value] == 416
             assert result[DeviceAttributes.water_pump_running.value] is False
+            assert result[DeviceAttributes.target_outdoor_fan_speed.value] == 600
+            assert result[DeviceAttributes.target_expansion_valve_angle.value] == 248
+            assert result[DeviceAttributes.defrost_stage.value] == 2
             assert result[DeviceAttributes.compressor_power.value] == 269
 
     def test_set_attribute_group_data_is_read_only(self) -> None:
@@ -729,6 +736,9 @@ class TestMideaACDevice:
                 DeviceAttributes.indoor_fan_speed,
                 DeviceAttributes.target_indoor_fan_speed,
                 DeviceAttributes.water_pump_running,
+                DeviceAttributes.target_outdoor_fan_speed,
+                DeviceAttributes.target_expansion_valve_angle,
+                DeviceAttributes.defrost_stage,
                 DeviceAttributes.compressor_power,
             ]:
                 self.device.set_attribute(attr.value, 1)

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1251,7 +1251,7 @@ class TestMessageACResponse:
         assert response.indoor_humidity is None
 
     def test_message_query_c1_0x45_short_body(self) -> None:
-        """Test missing group 5 fields use read-byte defaults."""
+        """Test missing group 5 fields remain unavailable."""
         self.header[9] = 0x03
         body = bytearray(8)
         body[0] = 0xC1
@@ -1261,12 +1261,9 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "indoor_humidity")
         assert response.indoor_humidity == 55
-        assert hasattr(response, "target_outdoor_fan_speed")
-        assert response.target_outdoor_fan_speed == 0
-        assert hasattr(response, "target_expansion_valve_angle")
-        assert response.target_expansion_valve_angle == 0
-        assert hasattr(response, "defrost_stage")
-        assert response.defrost_stage == 0
+        assert not hasattr(response, "target_outdoor_fan_speed")
+        assert not hasattr(response, "target_expansion_valve_angle")
+        assert not hasattr(response, "defrost_stage")
 
     def test_message_query_c1_unknown_method(self) -> None:
         """Test Message parse query C1 with an unknown analysis method."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1226,20 +1226,44 @@ class TestMessageACResponse:
         assert response.fresh_filter_timeout == 1
 
     def test_message_query_c1_0x45(self) -> None:
-        """Test Message parse query C1 0x45 indoor humidity."""
+        """Test Message parse query C1 0x45 group 5 diagnostics."""
         self.header[9] = 0x03
         body = bytearray(20)
         body[0] = 0xC1  # Body type
         body[3] = 0x45  # Set the type to 0x45
         body[4] = 55  # Indoor humidity
+        body[8] = 75  # Target outdoor fan speed: 75 * 8 = 600
+        body[9] = 31  # Target EEV opening: 31 * 8 = 248
+        body[10] = 2  # Defrost stage
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "indoor_humidity")
         assert response.indoor_humidity == 55
+        assert hasattr(response, "target_outdoor_fan_speed")
+        assert response.target_outdoor_fan_speed == 600
+        assert hasattr(response, "target_expansion_valve_angle")
+        assert response.target_expansion_valve_angle == 248
+        assert hasattr(response, "defrost_stage")
+        assert response.defrost_stage == 2
 
         body[4] = 0  # Indoor humidity unavailable
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "indoor_humidity")
         assert response.indoor_humidity is None
+
+    def test_message_query_c1_0x45_short_body(self) -> None:
+        """Test short group 5 responses retain humidity compatibility."""
+        self.header[9] = 0x03
+        body = bytearray(8)
+        body[0] = 0xC1
+        body[3] = 0x45
+        body[4] = 55
+
+        response = MessageACResponse(self.header + body)
+        assert hasattr(response, "indoor_humidity")
+        assert response.indoor_humidity == 55
+        assert not hasattr(response, "target_outdoor_fan_speed")
+        assert not hasattr(response, "target_expansion_valve_angle")
+        assert not hasattr(response, "defrost_stage")
 
     def test_message_query_c1_unknown_method(self) -> None:
         """Test Message parse query C1 with an unknown analysis method."""

--- a/tests/devices/ac/message_ac_test.py
+++ b/tests/devices/ac/message_ac_test.py
@@ -1251,7 +1251,7 @@ class TestMessageACResponse:
         assert response.indoor_humidity is None
 
     def test_message_query_c1_0x45_short_body(self) -> None:
-        """Test short group 5 responses retain humidity compatibility."""
+        """Test missing group 5 fields use read-byte defaults."""
         self.header[9] = 0x03
         body = bytearray(8)
         body[0] = 0xC1
@@ -1261,9 +1261,12 @@ class TestMessageACResponse:
         response = MessageACResponse(self.header + body)
         assert hasattr(response, "indoor_humidity")
         assert response.indoor_humidity == 55
-        assert not hasattr(response, "target_outdoor_fan_speed")
-        assert not hasattr(response, "target_expansion_valve_angle")
-        assert not hasattr(response, "defrost_stage")
+        assert hasattr(response, "target_outdoor_fan_speed")
+        assert response.target_outdoor_fan_speed == 0
+        assert hasattr(response, "target_expansion_valve_angle")
+        assert response.target_expansion_valve_angle == 0
+        assert hasattr(response, "defrost_stage")
+        assert response.defrost_stage == 0
 
     def test_message_query_c1_unknown_method(self) -> None:
         """Test Message parse query C1 with an unknown analysis method."""


### PR DESCRIPTION
## Summary

- extend the existing AC group 5 response parser with target outdoor-fan speed
- expose target electronic-expansion-valve angle
- expose the complete defrost stage instead of reducing it to a Boolean
- keep all three attributes read-only and preserve compatibility with short humidity-only responses

Addresses the group 5 portion of #424.

## Protocol evidence

The existing `MessageHumidityQuery` already requests group 5 (`0x45`). A bundled Midea AC plugin maps these group 5 body offsets:

| Body offset | Interpretation | Decoding |
|---:|---|---:|
| 8 | target outdoor-fan speed | `raw * 8` |
| 9 | target electronic-expansion-valve angle | `raw * 8` |
| 10 | defrost stage | integer stage |

Reference:

https://github.com/mill1000/midea-msmart/blob/04cdb96fbcbccdf75fe0772503c3bb772ff6af89/reference/0xAC/T0xAC_3.5.260526.zip

The outdoor-fan scaling also agrees with the independently implemented group 5 decoder in `midea-msmart`. That decoder currently converts offset 10 to a Boolean; retaining the integer here preserves the plugin's more precise defrost-stage semantics.

## Compatibility

- no additional query or network traffic is introduced because group 5 is already polled for indoor humidity
- each field is guarded by its own protocol offset and read with `read_byte()`
- responses long enough to contain humidity but shorter than the diagnostic fields continue to update humidity without exposing missing values
- the new attributes are initialized as unavailable and cannot generate set commands

## Validation

- `python -m pytest ./tests/` — 1,649 passed
- targeted AC tests — 149 passed
- `prek run --all-files` — all checks passed

Implementation and pull-request description written with OpenAI Codex (GPT-5.6-Sol).
