### PR TITLE
refactor(message): make missing byte reads optional

### DIFF
--- a/midealocal/devices/ac/message.py
+++ b/midealocal/devices/ac/message.py
@@ -1459,7 +1459,7 @@ class XC1MessageBody(MessageBody):
         # in units of 8 RPM. The engineer display labels the matching raw byte
         # as set speed, but group 5 exposes that target separately.
         self.outdoor_fan_speed = (
-            self.read_byte(body, XC1_GROUP_THREE_SPEED_OFFSET) * XC1_FAN_SPEED_FACTOR
+            self.read_byte(body, XC1_GROUP_THREE_SPEED_OFFSET, 0) * XC1_FAN_SPEED_FACTOR
         )
 
     def _parse_group_seven(self, body: bytearray) -> None:

--- a/midealocal/devices/b8/message.py
+++ b/midealocal/devices/b8/message.py
@@ -283,40 +283,40 @@ class MessageB8GenericBody(MessageBody):
         """Initialize B8 message generic body."""
         super().__init__(body)
         try:
-            self.work_status = B8WorkStatus(self.read_byte(body, 1 + offset))
+            self.work_status = B8WorkStatus(self.read_byte(body, 1 + offset, 0))
         except ValueError:
             self.work_status = B8WorkStatus.NONE
         try:
-            self.function_type = B8FunctionType(self.read_byte(body, 2 + offset))
+            self.function_type = B8FunctionType(self.read_byte(body, 2 + offset, 0))
         except ValueError:
             self.function_type = B8FunctionType.NONE
         try:
-            self.control_type = B8ControlType(self.read_byte(body, 3 + offset))
+            self.control_type = B8ControlType(self.read_byte(body, 3 + offset, 0))
         except ValueError:
             self.control_type = B8ControlType.NONE
         try:
-            self.move_direction = B8Moviment(self.read_byte(body, 4 + offset))
+            self.move_direction = B8Moviment(self.read_byte(body, 4 + offset, 0))
         except ValueError:
             self.move_direction = B8Moviment.NONE
         try:
-            self.clean_mode = B8CleanMode(self.read_byte(body, 5 + offset))
+            self.clean_mode = B8CleanMode(self.read_byte(body, 5 + offset, 0))
         except ValueError:
             self.clean_mode = B8CleanMode.NONE
         try:
-            self.fan_level = B8FanLevel(self.read_byte(body, 6 + offset))
+            self.fan_level = B8FanLevel(self.read_byte(body, 6 + offset, 0))
         except ValueError:
             self.fan_level = B8FanLevel.OFF
-        self.area = self.read_byte(body, 7 + offset)
+        self.area = self.read_byte(body, 7 + offset, 0)
         try:
-            self.water_level = B8WaterLevel(self.read_byte(body, 8 + offset))
+            self.water_level = B8WaterLevel(self.read_byte(body, 8 + offset, 0))
         except ValueError:
             self.water_level = B8WaterLevel.OFF
-        self.voice_volume = min(self.read_byte(body, 9 + offset), 100)
-        self.have_reserve_task = self.read_byte(body, 10 + offset) != 0
-        self.battery_percent = min(self.read_byte(body, 11 + offset), 100)
-        self.work_time = self.read_byte(body, 12 + offset)
+        self.voice_volume = min(self.read_byte(body, 9 + offset, 0), 100)
+        self.have_reserve_task = self.read_byte(body, 10 + offset, 0) != 0
+        self.battery_percent = min(self.read_byte(body, 11 + offset, 0), 100)
+        self.work_time = self.read_byte(body, 12 + offset, 0)
 
-        status_byte = self.read_byte(body, 13 + offset)
+        status_byte = self.read_byte(body, 13 + offset, 0)
         self.uv_switch = (status_byte & 0x01) > 0
         self.wifi_switch = (status_byte & 0x02) > 0
         self.voice_switch = (status_byte & 0x04) > 0
@@ -324,24 +324,24 @@ class MessageB8GenericBody(MessageBody):
         self.device_error = (status_byte & 0x80) > 0
 
         try:
-            self.error_type = B8ErrorType(self.read_byte(body, 14 + offset))
+            self.error_type = B8ErrorType(self.read_byte(body, 14 + offset, 0))
         except ValueError:
             self.error_type = B8ErrorType.NO
 
         try:
-            self.mop = B8MopState(self.read_byte(body, 16 + offset))
+            self.mop = B8MopState(self.read_byte(body, 16 + offset, 0))
         except ValueError:
             self.mop = B8MopState.LACK_WATER
 
-        self.carpet_switch = self.read_byte(body, 17 + offset) != 0
+        self.carpet_switch = self.read_byte(body, 17 + offset, 0) != 0
 
-        error_byte = self.read_byte(body, 18 + offset)
+        error_byte = self.read_byte(body, 18 + offset, 0)
         self.laser_sensor_error = (error_byte & 0x01) > 0
         self.laser_sensor_shelter = (error_byte & 0x02) > 0
         self.board_communication_error = (error_byte & 0x04) > 0
 
         try:
-            self.speed = B8Speed(self.read_byte(body, 19 + offset))
+            self.speed = B8Speed(self.read_byte(body, 19 + offset, 0))
         except ValueError:
             self.speed = B8Speed.HIGH
 
@@ -353,21 +353,21 @@ class MessageB8GenericBody(MessageBody):
         if self.error_type == B8ErrorType.CAN_FIX:
             try:
                 self.error_desc = B8ErrorCanFixDescription(
-                    self.read_byte(body, 15 + offset),
+                    self.read_byte(body, 15 + offset, 0),
                 )
             except ValueError:
                 self.error_desc = B8ErrorCanFixDescription.NO
         elif self.error_type == B8ErrorType.REBOOT:
             try:
                 self.error_desc = B8ErrorRebootDescription(
-                    self.read_byte(body, 15 + offset),
+                    self.read_byte(body, 15 + offset, 0),
                 )
             except ValueError:
                 self.error_desc = B8ErrorRebootDescription.NO
         elif self.error_type == B8ErrorType.WARNING:
             try:
                 self.error_desc = B8ErrorWarningDescription(
-                    self.read_byte(body, 15 + offset),
+                    self.read_byte(body, 15 + offset, 0),
                 )
             except ValueError:
                 self.error_desc = B8ErrorWarningDescription.NO

--- a/midealocal/devices/ca/message.py
+++ b/midealocal/devices/ca/message.py
@@ -64,22 +64,22 @@ class CAGeneralMessageBody(MessageBody):
         """Initialize CA message general body."""
         super().__init__(body)
 
-        self.code_mode = (self.read_byte(body, 1) & 0x01) > 0
-        self.freezing_mode = (self.read_byte(body, 1) & 0x02) > 0
-        self.smart_mode = (self.read_byte(body, 1) & 0x04) > 0
-        self.energy_saving_mode = (self.read_byte(body, 1) & 0x08) > 0
-        self.holiday_mode = (self.read_byte(body, 1) & 0x10) > 0
-        self.moisturize_mode = (self.read_byte(body, 1) & 0x20) > 0
-        self.preservation_mode = (self.read_byte(body, 1) & 0x40) > 0
-        self.acmeFreezing_mode = (self.read_byte(body, 1) & 0x80) > 0
+        self.code_mode = (self.read_byte(body, 1, 0) & 0x01) > 0
+        self.freezing_mode = (self.read_byte(body, 1, 0) & 0x02) > 0
+        self.smart_mode = (self.read_byte(body, 1, 0) & 0x04) > 0
+        self.energy_saving_mode = (self.read_byte(body, 1, 0) & 0x08) > 0
+        self.holiday_mode = (self.read_byte(body, 1, 0) & 0x10) > 0
+        self.moisturize_mode = (self.read_byte(body, 1, 0) & 0x20) > 0
+        self.preservation_mode = (self.read_byte(body, 1, 0) & 0x40) > 0
+        self.acmeFreezing_mode = (self.read_byte(body, 1, 0) & 0x80) > 0
         # refrigerationTemperature
-        self.refrigerator_setting_temp = self.read_byte(body, 2) & 0x0F
+        self.refrigerator_setting_temp = self.read_byte(body, 2, 0) & 0x0F
         # freezingTemperature
-        self.freezer_setting_temp = -12 - ((self.read_byte(body, 2) & 0xF0) >> 4)
+        self.freezer_setting_temp = -12 - ((self.read_byte(body, 2, 0) & 0xF0) >> 4)
         # lVariableTemperature
-        flex_zone_setting_temp = self.read_byte(body, 3)
+        flex_zone_setting_temp = self.read_byte(body, 3, 0)
         # rVariableTemperature
-        right_flex_zone_setting_temp = self.read_byte(body, 4)
+        right_flex_zone_setting_temp = self.read_byte(body, 4, 0)
 
         if TEMP_POS_LOWER_VALUE <= flex_zone_setting_temp <= TEMP_POS_UPPER_VALUE:
             self.flex_zone_setting_temp = flex_zone_setting_temp - 19
@@ -96,103 +96,114 @@ class CAGeneralMessageBody(MessageBody):
         else:
             self.right_flex_zone_setting_temp = 0
 
-        self.variable_mode = self.read_byte(body, 5)  # variableModeValue
+        self.variable_mode = self.read_byte(body, 5, 0)  # variableModeValue
         # *powerValue 0x00 is on, 0x04/0x08/0x10/20 is off
         self.refrigeration_power = (
-            self.read_byte(body, 6) & 0x01
+            self.read_byte(body, 6, 0) & 0x01
         ) < 1  # refrigerationPowerValue
         self.l_variable_power = (
-            self.read_byte(body, 6) & 0x04
+            self.read_byte(body, 6, 0) & 0x04
         ) < 1  # lVariablePowerValue
         self.r_variable_power = (
-            self.read_byte(body, 6) & 0x08
+            self.read_byte(body, 6, 0) & 0x08
         ) < 1  # rVariablePowerValue
-        self.freezing_power = (self.read_byte(body, 6) & 0x10) < 1  # freezingPowerValue
+        self.freezing_power = (
+            self.read_byte(body, 6, 0) & 0x10
+        ) < 1  # freezingPowerValue
         self.cross_peak_electricity_enter = (
-            self.read_byte(body, 6) & 0x20
+            self.read_byte(body, 6, 0) & 0x20
         )  # crossPeakElectricityEnter
         self.cross_peak_electricity = (
-            self.read_byte(body, 6) & 0x40
+            self.read_byte(body, 6, 0) & 0x40
         ) > 0  # crossPeakElectricity
         self.all_refrigeration_power = (
-            self.read_byte(body, 6) & 0x80
+            self.read_byte(body, 6, 0) & 0x80
         ) > 0  # allRefrigerationPower
-        self.remove_dew = self.read_byte(body, 7) & 0x01  # removeDew
-        self.humidify = self.read_byte(body, 7) & 0x02  # humidify
-        self.unfreeze = self.read_byte(body, 7) & 0x04  # unfreeze
+        self.remove_dew = self.read_byte(body, 7, 0) & 0x01  # removeDew
+        self.humidify = self.read_byte(body, 7, 0) & 0x02  # humidify
+        self.unfreeze = self.read_byte(body, 7, 0) & 0x04  # unfreeze
         # 0x08 fahrenheit, 0x00 celsius
-        self.temperature_unit = self.read_byte(body, 7) & 0x08  # temperatureUnit
-        self.flood_light = self.read_byte(body, 7) & 0x10  # floodlight
+        self.temperature_unit = self.read_byte(body, 7, 0) & 0x08  # temperatureUnit
+        self.flood_light = self.read_byte(body, 7, 0) & 0x10  # floodlight
         # functionSwitch for icea_bar_function_switch
-        self.function_switch = self.read_byte(body, 7) & 0xC0  # functionSwitch
-        self.radar_mode = self.read_byte(body, 8) & 0x01  # radarMode
-        self.milk_mode = self.read_byte(body, 8) & 0x02  # milkMode
-        self.iced_mode = self.read_byte(body, 8) & 0x04  # icedMode
-        self.plasma_aseptic_mode = self.read_byte(body, 8) & 0x08  # plasmaAsepticMode
-        self.acquire_icea_mode = self.read_byte(body, 8) & 0x10  # acquireIceaMode
-        self.brash_icea_mode = self.read_byte(body, 8) & 0x20  # brashIceaMode
-        self.acquire_water_mode = self.read_byte(body, 8) & 0x40  # acquireWaterMode
+        self.function_switch = self.read_byte(body, 7, 0) & 0xC0  # functionSwitch
+        self.radar_mode = self.read_byte(body, 8, 0) & 0x01  # radarMode
+        self.milk_mode = self.read_byte(body, 8, 0) & 0x02  # milkMode
+        self.iced_mode = self.read_byte(body, 8, 0) & 0x04  # icedMode
+        self.plasma_aseptic_mode = (
+            self.read_byte(body, 8, 0) & 0x08
+        )  # plasmaAsepticMode
+        self.acquire_icea_mode = self.read_byte(body, 8, 0) & 0x10  # acquireIceaMode
+        self.brash_icea_mode = self.read_byte(body, 8, 0) & 0x20  # brashIceaMode
+        self.acquire_water_mode = self.read_byte(body, 8, 0) & 0x40  # acquireWaterMode
         self.freezing_ice_machine_power = (
-            self.read_byte(body, 8) & 0x80
+            self.read_byte(body, 8, 0) & 0x80
         )  # freezingIceMachinePower
-        self.freezing_fahrenheit = self.read_byte(body, 9)  # freezingFahrenheit
+        self.freezing_fahrenheit = self.read_byte(body, 9, 0)  # freezingFahrenheit
         self.refrigeration_fahrenheit = (
-            self.read_byte(body, 10) & 0xFC
+            self.read_byte(body, 10, 0) & 0xFC
         )  # refrigerationFahrenheit
-        self.leach_expire_day = self.read_byte(body, 11)  # leachExpireDay
+        self.leach_expire_day = self.read_byte(body, 11, 0)  # leachExpireDay
 
         # powerConsumptionLow & powerConsumptionHigh
-        self.energy_consumption = (self.read_byte(body, 13) << 8) + self.read_byte(
+        self.energy_consumption = (self.read_byte(body, 13, 0) << 8) + self.read_byte(
             body,
             12,
+            default_value=0,
         )
 
         self.freezing_motor_reset_status = (
-            self.read_byte(body, 14) & 0x01
+            self.read_byte(body, 14, 0) & 0x01
         )  # freezingMotorResetStatus
         self.freezing_motor_deicing_status = (
-            self.read_byte(body, 14) & 0x02
+            self.read_byte(body, 14, 0) & 0x02
         )  # freezingMotorDeicingStatus
         self.freezing_ice_machine_water_status = (
-            self.read_byte(body, 14) & 0x04
+            self.read_byte(body, 14, 0) & 0x04
         )  # freezingIceMachineWaterStatus
         self.freezing_all_ice_status = (
-            self.read_byte(body, 14) & 0x08
+            self.read_byte(body, 14, 0) & 0x08
         )  # freezingAllIceStatus
-        self.human_induction = self.read_byte(body, 14) & 0x10  # humanInduction
+        self.human_induction = self.read_byte(body, 14, 0) & 0x10  # humanInduction
         self.refrigeration_door_power = (
-            self.read_byte(body, 15) & 0x01
+            self.read_byte(body, 15, 0) & 0x01
         )  # refrigerationDoorPower
-        self.freezing_door_power = self.read_byte(body, 15) & 0x02  # freezingDoorPower
-        self.variable_door_power = self.read_byte(body, 15) & 0x10  # variableDoorPower
+        self.freezing_door_power = (
+            self.read_byte(body, 15, 0) & 0x02
+        )  # freezingDoorPower
+        self.variable_door_power = (
+            self.read_byte(body, 15, 0) & 0x10
+        )  # variableDoorPower
         self.storage_iceHome_door_state = (
-            self.read_byte(body, 15) & 0x20
+            self.read_byte(body, 15, 0) & 0x20
         )  # storageIceHomeDoorState
-        self.bar_door_power = self.read_byte(body, 15) & 0x04  # barDoorPower
-        self.ice_mouth_power = self.read_byte(body, 15) & 0x08  # iceMouthPower
-        self.is_error = self.read_byte(body, 16) & 0x01  # isError
+        self.bar_door_power = self.read_byte(body, 15, 0) & 0x04  # barDoorPower
+        self.ice_mouth_power = self.read_byte(body, 15, 0) & 0x08  # iceMouthPower
+        self.is_error = self.read_byte(body, 16, 0) & 0x01  # isError
         self.interval_room_humidity_level = (
-            self.read_byte(body, 16) & 0xFE
+            self.read_byte(body, 16, 0) & 0xFE
         )  # intervalRoomHumidityLevel
 
         # refrigerationRealTemperature
-        self.refrigerator_actual_temp = (self.read_byte(body, 17) - 100) / 2
+        self.refrigerator_actual_temp = (self.read_byte(body, 17, 0) - 100) / 2
         # freezingRealTemperature
-        self.freezer_actual_temp = (self.read_byte(body, 18) - 100) / 2
+        self.freezer_actual_temp = (self.read_byte(body, 18, 0) - 100) / 2
         # lVariableRealTemperature
-        self.flex_zone_actual_temp = (self.read_byte(body, 19) - 100) / 2
+        self.flex_zone_actual_temp = (self.read_byte(body, 19, 0) - 100) / 2
         # rVariableRealTemperature
-        self.right_flex_zone_actual_temp = (self.read_byte(body, 20) - 100) / 2
+        self.right_flex_zone_actual_temp = (self.read_byte(body, 20, 0) - 100) / 2
 
         # fastColdMinuteLow & fastColdMinuteHigh
-        self.fast_cold_minute = (self.read_byte(body, 22) << 8) + self.read_byte(
+        self.fast_cold_minute = (self.read_byte(body, 22, 0) << 8) + self.read_byte(
             body,
             21,
+            default_value=0,
         )
         # fastFreezeMinuteLow & fastFreezeMinuteHigh
-        self.fast_freeze_minute = (self.read_byte(body, 24) << 8) + self.read_byte(
+        self.fast_freeze_minute = (self.read_byte(body, 24, 0) << 8) + self.read_byte(
             body,
             23,
+            default_value=0,
         )
 
         if len(body) > CA_GENERAL_BODY_LENGTH1:

--- a/midealocal/devices/e8/message.py
+++ b/midealocal/devices/e8/message.py
@@ -64,26 +64,26 @@ class E8MessageBody(MessageBody):
     def __init__(self, body: bytearray) -> None:
         """Initialize E8 message body."""
         super().__init__(body)
-        self.status = self.read_byte(body, 11)
+        self.status = self.read_byte(body, 11, 0)
         self.time_remaining = (
-            self.read_byte(body, 16) * 3600
-            + self.read_byte(body, 17) * 60
-            + self.read_byte(body, 18)
+            self.read_byte(body, 16, 0) * 3600
+            + self.read_byte(body, 17, 0) * 60
+            + self.read_byte(body, 18, 0)
         )
         self.keep_warm_remaining = (
-            self.read_byte(body, 19) * 3600
-            + self.read_byte(body, 20) * 60
-            + self.read_byte(body, 21)
+            self.read_byte(body, 19, 0) * 3600
+            + self.read_byte(body, 20, 0) * 60
+            + self.read_byte(body, 21, 0)
         )
         self.working_time = (
-            self.read_byte(body, 28) * 3600
-            + self.read_byte(body, 29) * 60
-            + self.read_byte(body, 30)
+            self.read_byte(body, 28, 0) * 3600
+            + self.read_byte(body, 29, 0) * 60
+            + self.read_byte(body, 30, 0)
         )
-        self.target_temperature = self.read_byte(body, 39)
-        self.current_temperature = self.read_byte(body, 39)
-        self.finished = (self.read_byte(body, 41) & 0x01) > 0
-        self.water_shortage = self.read_byte(body, 43) > 0
+        self.target_temperature = self.read_byte(body, 39, 0)
+        self.current_temperature = self.read_byte(body, 39, 0)
+        self.finished = (self.read_byte(body, 41, 0) & 0x01) > 0
+        self.water_shortage = self.read_byte(body, 43, 0) > 0
 
 
 class MessageE8Response(MessageResponse):
@@ -92,7 +92,7 @@ class MessageE8Response(MessageResponse):
     def __init__(self, message: bytes) -> None:
         """Initialize E8 message response."""
         super().__init__(bytearray(message))
-        sub_cmd = MessageBody.read_byte(super().body, 6)
+        sub_cmd = MessageBody.read_byte(super().body, 6, 0)
         if (
             (
                 self.message_type == MessageType.set

--- a/midealocal/devices/x13/message.py
+++ b/midealocal/devices/x13/message.py
@@ -89,12 +89,12 @@ class MessageMainLightBody(MessageBody):
     def __init__(self, body: bytearray) -> None:
         """Initialize X13 message main light body."""
         super().__init__(body)
-        self.brightness = self.read_byte(body, 1)
-        self.color_temperature = self.read_byte(body, 2)
-        self.effect = self.read_byte(body, 3) - 1
+        self.brightness = self.read_byte(body, 1, 0)
+        self.color_temperature = self.read_byte(body, 2, 0)
+        self.effect = self.read_byte(body, 3, 0) - 1
         if self.effect > MAX_EFFECT:
             self.effect = 1
-        self.power = self.read_byte(body, 8) > 0
+        self.power = self.read_byte(body, 8, 0) > 0
 
 
 class MessageMainLightResponseBody(MessageBody):

--- a/midealocal/devices/x26/message.py
+++ b/midealocal/devices/x26/message.py
@@ -146,25 +146,25 @@ class Message26Body(MessageBody):
         """Initialize X26 message body."""
         super().__init__(body)
         self.fields = self._gen_fields(body)
-        self.main_light = self.read_byte(body, 1) > 0
-        self.night_light = self.read_byte(body, 3) > 0
-        heat_mode = self.read_byte(body, 9) > 0
-        heat_temperature = self.read_byte(body, 10)
-        heat_direction = self.read_byte(body, 12)
-        bath_mode = self.read_byte(body, 13) > 0
-        bath_direction = self.read_byte(body, 17)
-        ventilation_mode = self.read_byte(body, 18) > 0
-        ventilation_direction = self.read_byte(body, 20)
-        dry_mode = self.read_byte(body, 21) > 0
-        dry_direction = self.read_byte(body, 25)
-        blow_mode = self.read_byte(body, 26) > 0
-        blow_direction = self.read_byte(body, 28)
-        if self.read_byte(body, 31) != MAX_BYTE_VALUE:
-            self.current_humidity = self.read_byte(body, 31)
-        if self.read_byte(body, 32) != MAX_BYTE_VALUE:
-            self.current_radar = self.read_byte(body, 32)
-        if self.read_byte(body, 33) != MAX_BYTE_VALUE:
-            self.current_temperature = self.read_byte(body, 33)
+        self.main_light = self.read_byte(body, 1, 0) > 0
+        self.night_light = self.read_byte(body, 3, 0) > 0
+        heat_mode = self.read_byte(body, 9, 0) > 0
+        heat_temperature = self.read_byte(body, 10, 0)
+        heat_direction = self.read_byte(body, 12, 0)
+        bath_mode = self.read_byte(body, 13, 0) > 0
+        bath_direction = self.read_byte(body, 17, 0)
+        ventilation_mode = self.read_byte(body, 18, 0) > 0
+        ventilation_direction = self.read_byte(body, 20, 0)
+        dry_mode = self.read_byte(body, 21, 0) > 0
+        dry_direction = self.read_byte(body, 25, 0)
+        blow_mode = self.read_byte(body, 26, 0) > 0
+        blow_direction = self.read_byte(body, 28, 0)
+        if self.read_byte(body, 31, 0) != MAX_BYTE_VALUE:
+            self.current_humidity = self.read_byte(body, 31, 0)
+        if self.read_byte(body, 32, 0) != MAX_BYTE_VALUE:
+            self.current_radar = self.read_byte(body, 32, 0)
+        if self.read_byte(body, 33, 0) != MAX_BYTE_VALUE:
+            self.current_temperature = self.read_byte(body, 33, 0)
         self.mode = 0
         self.direction = 0xFD
         if heat_mode:
@@ -188,32 +188,32 @@ class Message26Body(MessageBody):
 
     def _gen_fields(self, body: bytearray) -> dict[str, int]:
         fields: dict[str, int] = {}
-        fields["MAIN_LIGHT_BRIGHTNESS"] = self.read_byte(body, 2)
-        fields["NIGHT_LIGHT_BRIGHTNESS"] = self.read_byte(body, 4)
-        fields["RADAR_INDUCTION_ENABLE"] = self.read_byte(body, 5)
-        fields["RADAR_INDUCTION_CLOSING_TIME"] = self.read_byte(body, 6)
-        fields["LIGHT_INTENSITY_THRESHOLD"] = self.read_byte(body, 7)
-        fields["RADAR_SENSITIVITY"] = self.read_byte(body, 8)
-        fields["HEATING_SPEED"] = self.read_byte(body, 11)
-        fields["BATH_HEATING_TIME"] = self.read_byte(body, 14)
-        fields["BATH_TEMPERATURE"] = self.read_byte(body, 15)
-        fields["BATH_SPEED"] = self.read_byte(body, 16)
-        fields["VENTILATION_SPEED"] = self.read_byte(body, 19)
-        fields["DRYING_TIME"] = self.read_byte(body, 22)
-        fields["DRYING_TEMPERATURE"] = self.read_byte(body, 23)
-        fields["DRYING_SPEED"] = self.read_byte(body, 24)
-        fields["BLOWING_SPEED"] = self.read_byte(body, 27)
-        fields["DELAY_ENABLE"] = self.read_byte(body, 29)
-        fields["DELAY_TIME"] = self.read_byte(body, 30)
-        fields["SOFT_WIND_ENABLE"] = self.read_byte(body, 38)
-        fields["SOFT_WIND_TIME"] = self.read_byte(body, 39)
-        fields["SOFT_WIND_TEMPERATURE"] = self.read_byte(body, 40)
-        fields["SOFT_WIND_SPEED"] = self.read_byte(body, 41)
-        fields["SOFT_WIND_DIRECTION"] = self.read_byte(body, 42)
-        fields["WINDLESS_ENABLE"] = self.read_byte(body, 43)
-        fields["ANION_ENABLE"] = self.read_byte(body, 44)
-        fields["SMELLY_ENABLE"] = self.read_byte(body, 45)
-        fields["SMELLY_THRESHOLD"] = self.read_byte(body, 46)
+        fields["MAIN_LIGHT_BRIGHTNESS"] = self.read_byte(body, 2, 0)
+        fields["NIGHT_LIGHT_BRIGHTNESS"] = self.read_byte(body, 4, 0)
+        fields["RADAR_INDUCTION_ENABLE"] = self.read_byte(body, 5, 0)
+        fields["RADAR_INDUCTION_CLOSING_TIME"] = self.read_byte(body, 6, 0)
+        fields["LIGHT_INTENSITY_THRESHOLD"] = self.read_byte(body, 7, 0)
+        fields["RADAR_SENSITIVITY"] = self.read_byte(body, 8, 0)
+        fields["HEATING_SPEED"] = self.read_byte(body, 11, 0)
+        fields["BATH_HEATING_TIME"] = self.read_byte(body, 14, 0)
+        fields["BATH_TEMPERATURE"] = self.read_byte(body, 15, 0)
+        fields["BATH_SPEED"] = self.read_byte(body, 16, 0)
+        fields["VENTILATION_SPEED"] = self.read_byte(body, 19, 0)
+        fields["DRYING_TIME"] = self.read_byte(body, 22, 0)
+        fields["DRYING_TEMPERATURE"] = self.read_byte(body, 23, 0)
+        fields["DRYING_SPEED"] = self.read_byte(body, 24, 0)
+        fields["BLOWING_SPEED"] = self.read_byte(body, 27, 0)
+        fields["DELAY_ENABLE"] = self.read_byte(body, 29, 0)
+        fields["DELAY_TIME"] = self.read_byte(body, 30, 0)
+        fields["SOFT_WIND_ENABLE"] = self.read_byte(body, 38, 0)
+        fields["SOFT_WIND_TIME"] = self.read_byte(body, 39, 0)
+        fields["SOFT_WIND_TEMPERATURE"] = self.read_byte(body, 40, 0)
+        fields["SOFT_WIND_SPEED"] = self.read_byte(body, 41, 0)
+        fields["SOFT_WIND_DIRECTION"] = self.read_byte(body, 42, 0)
+        fields["WINDLESS_ENABLE"] = self.read_byte(body, 43, 0)
+        fields["ANION_ENABLE"] = self.read_byte(body, 44, 0)
+        fields["SMELLY_ENABLE"] = self.read_byte(body, 45, 0)
+        fields["SMELLY_THRESHOLD"] = self.read_byte(body, 46, 0)
 
         return fields
 

--- a/midealocal/message.py
+++ b/midealocal/message.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Callable
 from enum import IntEnum
-from typing import Any, SupportsIndex, cast
+from typing import Any, SupportsIndex, cast, overload
 
 from typing_extensions import deprecated
 
@@ -763,8 +763,24 @@ class MessageBody:
         return ListTypes(self._data[0])
 
     @staticmethod
-    def read_byte(body: bytearray, byte: int, default_value: int = 0) -> int:
-        """Read bytes for message body."""
+    @overload
+    def read_byte(
+        body: bytearray,
+        byte: int,
+        default_value: None = None,
+    ) -> int | None: ...
+
+    @staticmethod
+    @overload
+    def read_byte(body: bytearray, byte: int, default_value: int) -> int: ...
+
+    @staticmethod
+    def read_byte(
+        body: bytearray,
+        byte: int,
+        default_value: int | None = None,
+    ) -> int | None:
+        """Read a byte, returning the requested fallback when it is absent."""
         return body[byte] if len(body) > byte else default_value
 
     def parse_all(self) -> None:

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -260,6 +260,18 @@ class TestMessageBody:
         body = bytearray([0x0A, 0x0B])
         assert MessageBody.read_byte(body, byte, default_value=0x09) == expected
 
+    def test_read_byte_present(self) -> None:
+        """Test read_byte returns a present byte without a fallback."""
+        body = bytearray([0x0A, 0x0B])
+        assert MessageBody.read_byte(body, 1) == 0x0B
+
+    @pytest.mark.parametrize("byte", [2, 5])
+    def test_read_byte_missing(self, byte: int) -> None:
+        """Test read_byte returns None when the byte is out of range."""
+        body = bytearray([0x0A, 0x0B])
+        assert MessageBody.read_byte(body, byte) is None
+        assert MessageBody.read_byte(body, byte, default_value=None) is None
+
     def test_parse_all(self) -> None:
         """Test parse all."""
         data = bytearray(


### PR DESCRIPTION
## Summary

- make `MessageBody.read_byte()` return `None` when an index is absent and no fallback is supplied
- add overloads so callers that provide an integer fallback retain an `int` return type
- make every existing production parser request its current zero fallback explicitly
- add tests for present bytes, the implicit `None` fallback, explicit `None`, and custom integer fallbacks

## Motivation

The previous implicit zero fallback made an absent protocol field indistinguishable from a genuine zero reading. This is relevant to optional or short response bodies, where zero can be a valid device value.

Existing in-repository parsers keep their current runtime behavior by passing `0` explicitly. New parsers can omit the fallback when they need to preserve the distinction between an absent byte and a zero byte.

This intentionally changes the default contract for external callers that use `read_byte(body, index)` and rely on an absent index producing zero, so the PR is opened as a draft for API review.

Related discussion: #740.

## Validation

- `python -m pytest ./tests/` — 1,722 passed
- `prek run --all-files` — all checks passed

Implementation and pull-request description written with OpenAI Codex (GPT-5.6-Sol).
