### PR TITLE
feat: add public metod mode_options()

### DIFF
--- a/midealocal/devices/ca/__init__.py
+++ b/midealocal/devices/ca/__init__.py
@@ -59,6 +59,11 @@ class MideaCADevice(MideaDevice):
         0x20: "low",
     }
 
+    @classmethod
+    def mode_options(cls) -> list[str]:
+        """Return the distinct variable modes this device can report, in order."""
+        return list(dict.fromkeys(cls._variable_mode.values()))
+
     def __init__(
         self,
         *,

--- a/midealocal/devices/db/__init__.py
+++ b/midealocal/devices/db/__init__.py
@@ -194,6 +194,11 @@ class MideaDBDevice(MideaDevice):
         "unknown",
     ]
 
+    @classmethod
+    def mode_options(cls) -> list[str]:
+        """Return the distinct modes this device can report, in order."""
+        return list(cls._mode.values())
+
     def __init__(
         self,
         *,

--- a/midealocal/devices/ea/__init__.py
+++ b/midealocal/devices/ea/__init__.py
@@ -132,6 +132,11 @@ class MideaEADevice(MideaDevice):
     )
     _progress: ClassVar[list[str]] = ["idle", "delay", "cooking", "keep_warm"]
 
+    @classmethod
+    def mode_options(cls) -> list[str]:
+        """Return the distinct cooking modes this device can report, in order."""
+        return [mode for mode in cls._mode_list if mode != "unknown"]
+
     def __init__(
         self,
         *,

--- a/midealocal/devices/ec/__init__.py
+++ b/midealocal/devices/ec/__init__.py
@@ -144,6 +144,11 @@ class MideaECDevice(MideaDevice):
         "lid_open",
     ]
 
+    @classmethod
+    def mode_options(cls) -> list[str]:
+        """Return the distinct cooking modes this device can report, in order."""
+        return [mode for mode in cls._mode_list if mode != "unknown"]
+
     def __init__(
         self,
         *,

--- a/tests/devices/ca/device_ca_test.py
+++ b/tests/devices/ca/device_ca_test.py
@@ -93,6 +93,21 @@ class TestMideaCADevice:
         assert len(queries) == 1
         assert isinstance(queries[0], MessageQuery)
 
+    def test_mode_options(self) -> None:
+        """variable_mode_options de-duplicates the repeated mapping value."""
+        options = MideaCADevice.mode_options()
+        assert options == [
+            "none",
+            "soft_freezing",
+            "zero_fresh",
+            "cold_drink",
+            "fresh_product",
+            "partial_freezing",
+            "dry_zone",
+            "freeze_warm",
+        ]
+        assert len(options) == len(set(options))
+
     def test_process_message_general(self) -> None:
         """Test process message with a full general body."""
         body = _general_body(32)

--- a/tests/devices/db/device_db_test.py
+++ b/tests/devices/db/device_db_test.py
@@ -60,6 +60,15 @@ class TestMideaDBDevice:
         assert len(queries) == 1
         assert isinstance(queries[0], MessageQuery)
 
+    def test_mode_options(self) -> None:
+        """mode_options lists the DB modes in enum order."""
+        assert MideaDBDevice.mode_options() == [
+            "normal",
+            "factory_test",
+            "service",
+            "normal_continus",
+        ]
+
     @pytest.mark.parametrize(
         "message_type",
         [MessageType.query, MessageType.set],

--- a/tests/devices/ea/device_ea_test.py
+++ b/tests/devices/ea/device_ea_test.py
@@ -48,6 +48,14 @@ class TestMideaEADevice:
         assert len(queries) == 1
         assert isinstance(queries[0], MessageQuery)
 
+    def test_mode_options(self) -> None:
+        """mode_options drops the "unknown" padding and stays unique and ordered."""
+        options = MideaEADevice.mode_options()
+        assert "unknown" not in options
+        assert len(options) == len(set(options))
+        assert options[0] == "smart"
+        assert options[-2:] == ["clean", "keep_warm"]
+
     def test_set_attribute_noop(self) -> None:
         """Test set attribute is a no-op for this device."""
         self.device.set_attribute(DeviceAttributes.mode.value, 1)

--- a/tests/devices/ec/device_ec_test.py
+++ b/tests/devices/ec/device_ec_test.py
@@ -46,6 +46,14 @@ class TestMideaECDevice:
         assert len(queries) == 1
         assert isinstance(queries[0], MessageQuery)
 
+    def test_mode_options(self) -> None:
+        """mode_options drops "unknown" padding and keeps the EC-only tail entries."""
+        options = MideaECDevice.mode_options()
+        assert "unknown" not in options
+        assert len(options) == len(set(options))
+        assert options[0] == "smart"
+        assert options[-3:] == ["clean", "keep_warm", "diy"]
+
     def test_set_attribute(self) -> None:
         """Test set attribute is a no-op."""
         self.device.set_attribute(DeviceAttributes.cooking.value, True)


### PR DESCRIPTION
Add public methods to the library to encapsulate low-level operations and remove this implementation detail from Home Assistant.

This keeps low-level protocol handling confined to the library, while allowing Home Assistant to use a cleaner and higher-level API.
