### PR TITLE
refactor(cloud)!: raise typed errors for known cloud API failure codes

### DIFF
--- a/midealocal/cli.py
+++ b/midealocal/cli.py
@@ -29,7 +29,11 @@ from midealocal.device import (
 )
 from midealocal.devices import device_selector
 from midealocal.discover import SERIAL_TYPE1_LENGTH, discover
-from midealocal.exceptions import SocketException
+from midealocal.exceptions import (
+    CloudLoginError,
+    NoDeviceRegistered,
+    SocketException,
+)
 from midealocal.version import __version__
 
 _LOGGER = logging.getLogger("cli")
@@ -75,12 +79,29 @@ class MideaCLI:
     async def _get_keys(self, device_id: int) -> dict[int, dict[str, Any]]:
         cloud = await self._get_cloud()
         default_keys = await cloud.get_default_keys()
-        if not await cloud.login():
+        try:
+            logged_in = await cloud.login()
+        except CloudLoginError as err:
+            _LOGGER.warning(
+                "Cloud login failed (%s). Using only default keys.",
+                err,
+            )
+            return default_keys
+        if not logged_in:
             _LOGGER.warning(
                 "Failed to authenticate to the cloud. Using only default keys.",
             )
             return default_keys
-        cloud_keys = await cloud.get_cloud_keys(device_id)
+        try:
+            cloud_keys = await cloud.get_cloud_keys(device_id)
+        except NoDeviceRegistered:
+            _LOGGER.warning(
+                "The cloud account has no paired device matching id %s. "
+                "Sign in with the account that added the device in the Midea "
+                "app. Using only default keys.",
+                device_id,
+            )
+            return default_keys
 
         return {**cloud_keys, **default_keys}
 
@@ -324,7 +345,14 @@ class MideaCLI:
         """
         cloud = await self._get_cloud()
         _LOGGER.debug("Try to authenticate to the cloud.")
-        if not await cloud.login():
+        try:
+            logged_in = await cloud.login()
+        except CloudLoginError as err:
+            # A specific, expected login failure -- the code/meaning is the
+            # useful output, not a traceback.
+            _LOGGER.error("Cloud login failed: %s", err)  # noqa: TRY400
+            return
+        if not logged_in:
             _LOGGER.error("Failed to authenticate to the cloud.")
             return
 

--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -19,7 +19,13 @@ from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 
-from midealocal.exceptions import ElementMissing
+from midealocal.exceptions import (
+    CLOUD_ERROR_MEANINGS,
+    LOGIN_ERROR_CODES,
+    NO_PERMISSION_CODES,
+    ElementMissing,
+    cloud_api_error,
+)
 
 from .security import (
     CloudSecurity,
@@ -29,6 +35,10 @@ from .security import (
 )
 
 SN8_MIN_SERIAL_LENGTH = 17
+
+# Cloud error codes that have a dedicated, actionable exception subclass; every
+# other non-zero code is logged and surfaced as ``None``.
+RAISE_FOR_ERROR_CODES = NO_PERMISSION_CODES | LOGIN_ERROR_CODES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -216,6 +226,7 @@ class MideaCloud:
         endpoint: str,
         data: dict[str, Any],
         header: dict[str, Any] | None = None,
+        raise_for_error: bool = False,
     ) -> dict | None:
         header = header or {}
         if not data.get("reqId"):
@@ -266,9 +277,41 @@ class MideaCloud:
                     url,
                     repr(e),
                 )
-        if int(response["code"]) == 0 and "data" in response:
+        code = int(response["code"])
+        if code == 0 and "data" in response:
             return cast("dict", response["data"])
+        self._handle_error_code(
+            url,
+            code,
+            str(response.get("msg") or ""),
+            raise_for_error,
+        )
         return None
+
+    def _handle_error_code(
+        self,
+        url: str,
+        code: int,
+        message: str,
+        raise_for_error: bool,
+    ) -> None:
+        """Log a non-zero cloud error code and raise if it maps to a known error.
+
+        ``code`` -1 is the local "no reply" sentinel already logged by the
+        caller, so it is skipped here.
+        """
+        if code == -1:
+            return
+        meaning = CLOUD_ERROR_MEANINGS.get(code)
+        _LOGGER.warning(
+            "Midea cloud API url: %s rejected the request with code %s: %s%s",
+            url,
+            code,
+            message,
+            f" ({meaning})" if meaning else "",
+        )
+        if raise_for_error and code in RAISE_FOR_ERROR_CODES:
+            raise cloud_api_error(code, message)
 
     async def _get_login_id(self) -> str | None:
         data = self._make_general_data()
@@ -276,6 +319,7 @@ class MideaCloud:
         if response := await self._api_request(
             endpoint="/v1/user/login/id/get",
             data=data,
+            raise_for_error=True,
         ):
             return response.get("loginId")
         return None
@@ -318,6 +362,7 @@ class MideaCloud:
             response = await self._api_request(
                 endpoint="/v1/iot/secure/getToken",
                 data=data,
+                raise_for_error=True,
             )
             # Log only the entry count: the payload carries token/key material.
             tokens = (response or {}).get("tokenlist") or []
@@ -455,6 +500,7 @@ class MeijuCloud(MideaCloud):
             if response := await self._api_request(
                 endpoint="/mj/user/login",
                 data=data,
+                raise_for_error=True,
             ):
                 self._access_token = response["mdata"]["accessToken"]
                 self._security.set_aes_keys(
@@ -510,6 +556,7 @@ class MeijuCloud(MideaCloud):
                 response = await self._api_request(
                     endpoint="/v2/iot/secure/getToken",
                     data=data,
+                    raise_for_error=True,
                 )
                 # Log only the entry count: the payload carries token/key material.
                 tokens = (response or {}).get("tokenlist") or []
@@ -779,13 +826,14 @@ class SmartHomeCloud(MideaCloud):
         endpoint: str,
         data: dict[str, Any],
         header: dict[str, Any] | None = None,
+        raise_for_error: bool = False,
     ) -> dict[str, Any] | None:
         header = header or {}
         header.update(
             {"x-recipe-app": self._app_id, "authorization": f"Basic {self._auth_base}"},
         )
 
-        return await super()._api_request(endpoint, data, header)
+        return await super()._api_request(endpoint, data, header, raise_for_error)
 
     async def _re_route(self) -> None:
         data = self._make_general_data()
@@ -832,6 +880,7 @@ class SmartHomeCloud(MideaCloud):
             if response := await self._api_request(
                 endpoint="/mj/user/login",
                 data=data,
+                raise_for_error=True,
             ):
                 self._uid = response["uid"]
                 self._access_token = response["mdata"]["accessToken"]
@@ -1004,6 +1053,7 @@ class MideaAirCloud(MideaCloud):
         endpoint: str,
         data: dict[str, Any],
         header: dict[str, Any] | None = None,
+        raise_for_error: bool = False,
     ) -> dict[str, Any] | None:
         header = header or {}
         url = self._api_url + endpoint
@@ -1040,13 +1090,21 @@ class MideaAirCloud(MideaCloud):
                     url,
                     repr(e),
                 )
-        if int(response["errorCode"]) == 0:
+        error_code = int(response["errorCode"])
+        if error_code == 0:
             if "result" in response:
                 return cast("dict[str, Any]", response["result"])
             # The legacy lua endpoint returns its payload under "data" instead
             # of "result"; fall back to it so download_lua can read the url.
             if "data" in response:
                 return cast("dict[str, Any]", response["data"])
+        else:
+            self._handle_error_code(
+                url,
+                error_code,
+                str(response.get("msg") or ""),
+                raise_for_error,
+            )
         return None
 
     async def login(self) -> bool:
@@ -1066,6 +1124,7 @@ class MideaAirCloud(MideaCloud):
             if response := await self._api_request(
                 endpoint="/v1/user/login",
                 data=data,
+                raise_for_error=True,
             ):
                 self._access_token = response["accessToken"]
                 self._uid = response["userId"]

--- a/midealocal/exceptions.py
+++ b/midealocal/exceptions.py
@@ -41,3 +41,71 @@ class SocketException(MideaLocalError):
 
 class ValueWrongType(MideaLocalError):
     """Exception raised when the value has a wrong data type."""
+
+
+# Verified against mp-prod.appsmb.com. The wire message text varies by locale
+# and endpoint (65027 comes back in Chinese), so callers should branch on the
+# code; the meaning here is only for logging.
+CLOUD_ERROR_MEANINGS: dict[int, str] = {
+    3004: (
+        "malformed or rejected request: bad udpid/applianceCodes, or the "
+        "endpoint is disabled on this cloud"
+    ),
+    3102: "account or password incorrect",
+    3144: "login session is no longer valid (empty loginId); log in again",
+    3201: (
+        "the account has no permission for this device; it is bound to a "
+        "different account"
+    ),
+    7610: "too many failed login attempts; locked for about 5 minutes",
+    9999: "generic or transient cloud error",
+    65027: "maximum number of simultaneously logged-in devices exceeded",
+}
+
+# getToken / appliance endpoints answer with this when the authenticated account
+# does not own the appliance it asked about (device paired under another
+# account). See https://github.com/mill1000/midea-ac-py/issues/482.
+NO_PERMISSION_CODES = frozenset({3201})
+
+# Failures of the login / loginId step that a user has to act on (wrong
+# credentials, expired session, rate limit, device-count limit).
+LOGIN_ERROR_CODES = frozenset({3102, 3144, 7610, 65027})
+
+
+class MideaCloudError(MideaLocalError):
+    """Exception raised when a Midea cloud API request returns an error."""
+
+    def __init__(self, code: int, message: str) -> None:
+        """Initialize with the cloud error code and message."""
+        meaning = CLOUD_ERROR_MEANINGS.get(code)
+        detail = f"{message} ({meaning})" if meaning else message
+        super().__init__(f"Cloud request failed with code {code}: {detail}")
+        self.code = code
+        self.message = message
+
+
+class NoDeviceRegistered(MideaCloudError):
+    """Exception raised when the account has no paired device for the request.
+
+    The Midea cloud verifies device ownership before issuing a local token/key;
+    an account that did not pair the appliance itself cannot retrieve them.
+    See https://github.com/mill1000/midea-ac-py/issues/482.
+    """
+
+
+class CloudLoginError(MideaCloudError):
+    """Exception raised when the cloud login / loginId step fails with a known code.
+
+    Carries the cloud ``code`` so callers can map it to a specific message
+    (wrong credentials, expired session, rate limit, too many logged-in
+    devices); see ``LOGIN_ERROR_CODES`` and ``CLOUD_ERROR_MEANINGS``.
+    """
+
+
+def cloud_api_error(code: int, message: str) -> MideaCloudError:
+    """Return the most specific MideaCloudError subclass for a cloud error code."""
+    if code in NO_PERMISSION_CODES:
+        return NoDeviceRegistered(code, message)
+    if code in LOGIN_ERROR_CODES:
+        return CloudLoginError(code, message)
+    return MideaCloudError(code, message)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -36,6 +36,7 @@ _DEFAULT_KEYS = {99: {"key": "key99", "token": "token99"}}
 def cli() -> MideaCLI:
     """Return a MideaCLI with the minimal namespace the cloud-key paths need."""
     instance = MideaCLI()
+    instance.session = AsyncMock()
     instance.namespace = Namespace(
         cloud_name="SmartHome",
         username="user",

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -23,7 +23,62 @@ from midealocal.cloud import MideaAirCloud, SmartHomeCloud
 from midealocal.const import ProtocolVersion
 from midealocal.device import AuthException, NoSupportedProtocol
 from midealocal.discover import _extract_mac
-from midealocal.exceptions import NoDeviceRegistered, SocketException
+from midealocal.exceptions import (
+    CloudLoginError,
+    NoDeviceRegistered,
+    SocketException,
+)
+
+_DEFAULT_KEYS = {99: {"key": "key99", "token": "token99"}}
+
+
+@pytest.fixture
+def cli() -> MideaCLI:
+    """Return a MideaCLI with the minimal namespace the cloud-key paths need."""
+    instance = MideaCLI()
+    instance.namespace = Namespace(
+        cloud_name="SmartHome",
+        username="user",
+        password="pass",
+    )
+    return instance
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("login_side_effect", "get_cloud_keys_side_effect"),
+    [
+        pytest.param(
+            None,
+            NoDeviceRegistered(3201, "You have no permissions"),
+            id="device-bound-to-other-account",
+        ),
+        pytest.param(
+            CloudLoginError(7610, "rate limited"),
+            None,
+            id="login-rejected",
+        ),
+    ],
+)
+async def test_get_keys_falls_back_to_default_keys(
+    cli: MideaCLI,
+    login_side_effect: Exception | None,
+    get_cloud_keys_side_effect: Exception | None,
+) -> None:
+    """_get_keys returns only the default keys when the cloud path fails.
+
+    ``login_side_effect=None`` leaves an AsyncMock (truthy) so the flow reaches
+    ``get_cloud_keys``; a raised ``get_cloud_keys`` would break ``keys ==``.
+    """
+    mock_cloud = AsyncMock()
+    mock_cloud.get_default_keys.return_value = _DEFAULT_KEYS
+    mock_cloud.login.side_effect = login_side_effect
+    mock_cloud.get_cloud_keys.side_effect = get_cloud_keys_side_effect
+
+    with patch("midealocal.cli.get_midea_cloud", return_value=mock_cloud):
+        keys = await cli._get_keys(0)
+
+    assert keys == _DEFAULT_KEYS
 
 
 class TestMideaCLI(IsolatedAsyncioTestCase):
@@ -108,27 +163,6 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             assert keys[99]["token"] == "token99"
             mock_default_keys.assert_called_once()
             mock_cloud_keys.assert_not_called()
-
-    async def test_get_keys_no_paired_device(self) -> None:
-        """Test _get_keys falls back to default keys when the account owns none."""
-        mock_cloud = AsyncMock()
-        with (
-            patch("midealocal.cli.get_midea_cloud", return_value=mock_cloud),
-            patch.object(
-                mock_cloud,
-                "get_default_keys",
-                return_value={99: {"key": "key99", "token": "token99"}},
-            ),
-            patch.object(
-                mock_cloud,
-                "get_cloud_keys",
-                side_effect=NoDeviceRegistered(3201, "You have no permissions"),
-            ),
-            patch.object(mock_cloud, "login", return_value=True),
-        ):
-            keys = await self.cli._get_keys(0)
-
-        assert keys == {99: {"key": "key99", "token": "token99"}}
 
     def test_extract_mac(self) -> None:
         """Test _extract_mac."""
@@ -489,6 +523,18 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             await self.cli.download()
             mock_cloud_instance.download_lua.assert_called_once()
             mock_cloud_instance.download_plugin.assert_not_called()
+
+    async def test_download_cloud_login_error(self) -> None:
+        """download() bails out cleanly when login raises CloudLoginError."""
+        mock_cloud_instance = AsyncMock()
+        mock_cloud_instance.login.side_effect = CloudLoginError(7610, "rate limited")
+        with patch.object(self.cli, "_get_cloud", return_value=mock_cloud_instance):
+            self.namespace.host = None
+            self.namespace.device_sn = ""
+            # Must not raise, and must not proceed to enumerate appliances.
+            await self.cli.download()
+            mock_cloud_instance.list_appliances.assert_not_called()
+            mock_cloud_instance.download_lua.assert_not_called()
 
     async def test_download_plugin_error_is_isolated(self) -> None:
         """A plugin download error is logged without discarding the lua file."""

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -23,7 +23,7 @@ from midealocal.cloud import MideaAirCloud, SmartHomeCloud
 from midealocal.const import ProtocolVersion
 from midealocal.device import AuthException, NoSupportedProtocol
 from midealocal.discover import _extract_mac
-from midealocal.exceptions import SocketException
+from midealocal.exceptions import NoDeviceRegistered, SocketException
 
 
 class TestMideaCLI(IsolatedAsyncioTestCase):
@@ -108,6 +108,27 @@ class TestMideaCLI(IsolatedAsyncioTestCase):
             assert keys[99]["token"] == "token99"
             mock_default_keys.assert_called_once()
             mock_cloud_keys.assert_not_called()
+
+    async def test_get_keys_no_paired_device(self) -> None:
+        """Test _get_keys falls back to default keys when the account owns none."""
+        mock_cloud = AsyncMock()
+        with (
+            patch("midealocal.cli.get_midea_cloud", return_value=mock_cloud),
+            patch.object(
+                mock_cloud,
+                "get_default_keys",
+                return_value={99: {"key": "key99", "token": "token99"}},
+            ),
+            patch.object(
+                mock_cloud,
+                "get_cloud_keys",
+                side_effect=NoDeviceRegistered(3201, "You have no permissions"),
+            ),
+            patch.object(mock_cloud, "login", return_value=True),
+        ):
+            keys = await self.cli._get_keys(0)
+
+        assert keys == {99: {"key": "key99", "token": "token99"}}
 
     def test_extract_mac(self) -> None:
         """Test _extract_mac."""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -1,10 +1,12 @@
 """Test cloud."""
 
 import json
+import logging
 from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -115,6 +117,111 @@ async def test_msmartcloud_login_raises_cloud_login_error(code: int, msg: str) -
     with pytest.raises(CloudLoginError) as err:
         await cloud.login()
     assert err.value.code == code
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("read_side_effect", "warns_rejected"),
+    [
+        pytest.param(
+            [_RESPONSES["cloud_invalid_response.json"]] * 2,
+            True,
+            id="unclassified-code",
+        ),
+        pytest.param(
+            [json.dumps({"code": 9999, "msg": "system error"}).encode()] * 2,
+            True,
+            id="system-error-9999",
+        ),
+        pytest.param(
+            [_RESPONSES["msmartcloud_reroute.json"], *[ClientConnectionError()] * 3],
+            False,
+            id="unreachable",
+        ),
+    ],
+)
+async def test_msmartcloud_login_returns_false(
+    read_side_effect: list,
+    warns_rejected: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """login() returns False (never raises) for non-actionable failures.
+
+    The last case exhausts every retry with no JSON body, leaving the local
+    ``{"code": -1}`` sentinel, which must be logged as "already handled" -- no
+    "rejected the request" warning and no exception.
+    """
+    session = Mock()
+    response = Mock()
+    response.read = AsyncMock(side_effect=read_side_effect)
+    session.request = AsyncMock(return_value=response)
+    cloud = get_midea_cloud(
+        "SmartHome",
+        session=session,
+        account="account",
+        password="password",
+    )
+    with caplog.at_level(logging.WARNING, logger="midealocal.cloud"):
+        assert not await cloud.login()
+    assert ("rejected the request" in caplog.text) is warns_rejected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("get_token_reads", "expectation", "expected_keys"),
+    [
+        pytest.param(
+            [_RESPONSES["cloud_no_permission.json"]],
+            pytest.raises(NoDeviceRegistered),
+            None,
+            id="permission-error-raises",
+        ),
+        pytest.param(
+            [_RESPONSES["cloud_invalid_response.json"]] * 2,
+            nullcontext(),
+            {},
+            id="other-error-returns-empty",
+        ),
+    ],
+)
+async def test_msmartcloud_get_cloud_keys_error_handling(
+    get_token_reads: list[bytes],
+    expectation: AbstractContextManager[Any],
+    expected_keys: dict[int, dict[str, str]] | None,
+) -> None:
+    """get_cloud_keys raises NoDeviceRegistered on 3201, swallows other codes.
+
+    3201 means the account does not own the appliance, so callers can tell the
+    user to sign in with the account that paired it; any other non-zero code is
+    transient/unknown and must not abort key retrieval.
+    """
+    session = Mock()
+    response = Mock()
+    response.read = AsyncMock(
+        side_effect=[
+            _RESPONSES["msmartcloud_reroute.json"],
+            _RESPONSES["cloud_login_id.json"],
+            _RESPONSES["msmartcloud_login.json"],
+            *get_token_reads,
+        ],
+    )
+    session.request = AsyncMock(return_value=response)
+    cloud = get_midea_cloud(
+        "SmartHome",
+        session=session,
+        account="account",
+        password="password",
+    )
+    assert await cloud.login()
+
+    with expectation as err:
+        result = await cloud.get_cloud_keys(100)
+
+    if expected_keys is None:
+        assert err.value.code == 3201
+        assert err.value.message == "You have no permissions."
+    else:
+        assert result == expected_keys
 
 
 class CloudTest(IsolatedAsyncioTestCase):
@@ -732,39 +839,6 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert cloud is not None
         assert await cloud.login()
 
-    async def test_msmartcloud_login_invalid_user(self) -> None:
-        """Test MSmartCloud login invalid user."""
-        session = Mock()
-        response = Mock()
-        response.read = AsyncMock(
-            return_value=self.responses["cloud_invalid_response.json"],
-        )
-        session.request = AsyncMock(return_value=response)
-        cloud = get_midea_cloud(
-            "SmartHome",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert cloud is not None
-        assert not await cloud.login()
-
-    async def test_msmartcloud_login_generic_error_returns_false(self) -> None:
-        """Test an unclassified error code keeps the old login() -> False contract."""
-        session = Mock()
-        response = Mock()
-        response.read = AsyncMock(
-            return_value=json.dumps({"code": 9999, "msg": "system error"}).encode(),
-        )
-        session.request = AsyncMock(return_value=response)
-        cloud = get_midea_cloud(
-            "SmartHome",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert not await cloud.login()
-
     def test_cloud_api_error_factory(self) -> None:
         """Test cloud_api_error picks the most specific subclass per code."""
         assert type(cloud_api_error(3201, "")) is NoDeviceRegistered
@@ -776,63 +850,6 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert type(generic) is MideaCloudError
         assert "transient" in str(generic)
         assert cloud_api_error(4242, "boom").code == 4242
-
-    async def test_msmartcloud_get_cloud_keys_no_paired_device(self) -> None:
-        """Test get_cloud_keys raises NoDeviceRegistered on a permission error.
-
-        The SmartHome cloud answers getToken with code 3201 when the account
-        does not own the appliance, which must surface as a specific error so
-        callers can tell the user to use the account that paired the device.
-        """
-        session = Mock()
-        response = Mock()
-        response.read = AsyncMock(
-            side_effect=[
-                self.responses["msmartcloud_reroute.json"],
-                self.responses["cloud_login_id.json"],
-                self.responses["msmartcloud_login.json"],
-                self.responses["cloud_no_permission.json"],
-            ],
-        )
-        session.request = AsyncMock(return_value=response)
-        cloud = get_midea_cloud(
-            "SmartHome",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert cloud is not None
-        assert await cloud.login()
-
-        with pytest.raises(NoDeviceRegistered) as err:
-            await cloud.get_cloud_keys(100)
-        assert err.value.code == 3201
-        assert err.value.message == "You have no permissions."
-
-    async def test_msmartcloud_get_cloud_keys_other_error_returns_empty(self) -> None:
-        """Test get_cloud_keys swallows non-permission errors and returns no keys."""
-        session = Mock()
-        response = Mock()
-        response.read = AsyncMock(
-            side_effect=[
-                self.responses["msmartcloud_reroute.json"],
-                self.responses["cloud_login_id.json"],
-                self.responses["msmartcloud_login.json"],
-                self.responses["cloud_invalid_response.json"],
-                self.responses["cloud_invalid_response.json"],
-            ],
-        )
-        session.request = AsyncMock(return_value=response)
-        cloud = get_midea_cloud(
-            "SmartHome",
-            session=session,
-            account="account",
-            password="password",
-        )
-        assert cloud is not None
-        assert await cloud.login()
-
-        assert await cloud.get_cloud_keys(100) == {}
 
     async def test_msmartcloud_list_home(self) -> None:
         """Test MSmartCloud list_home."""

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -24,7 +24,13 @@ from midealocal.cloud import (
     get_midea_cloud,
     get_preset_account_cloud,
 )
-from midealocal.exceptions import ElementMissing
+from midealocal.exceptions import (
+    CloudLoginError,
+    ElementMissing,
+    MideaCloudError,
+    NoDeviceRegistered,
+    cloud_api_error,
+)
 
 # ``CloudSecurity.get_udp_id(100, method)``. Hard-coded on purpose: deriving them
 # with the same helper the implementation calls would not catch a request that
@@ -72,6 +78,43 @@ _TOSHIBA_ENCRYPTED_SN = (
     "a433df71998b41d4dc354e9bdf78902a"
 )
 _TOSHIBA_EXPECTED_SN = "0008AC0000000000000000000000BEEF"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("code", "msg"),
+    [
+        (3102, "Account or password incorrect, please re-enter"),
+        (3144, "login failed, loginId is empty, please login again"),
+        (7610, "Too many failed login attempts, please try again 5 minutes later"),
+        (65027, "该用户在线登录设备已超过上限,请更换账号登录"),
+    ],
+)
+async def test_msmartcloud_login_raises_cloud_login_error(code: int, msg: str) -> None:
+    """Test known login-step error codes surface as CloudLoginError.
+
+    3102/3144/7610/65027 are actionable failures of the login / loginId step;
+    callers need the code to show the right message, so login() must raise
+    rather than return a bare False.
+    """
+    session = Mock()
+    response = Mock()
+    response.read = AsyncMock(
+        side_effect=[
+            _RESPONSES["msmartcloud_reroute.json"],
+            json.dumps({"code": code, "msg": msg}).encode(),
+        ],
+    )
+    session.request = AsyncMock(return_value=response)
+    cloud = get_midea_cloud(
+        "SmartHome",
+        session=session,
+        account="account",
+        password="password",
+    )
+    with pytest.raises(CloudLoginError) as err:
+        await cloud.login()
+    assert err.value.code == code
 
 
 class CloudTest(IsolatedAsyncioTestCase):
@@ -705,6 +748,91 @@ class CloudTest(IsolatedAsyncioTestCase):
         )
         assert cloud is not None
         assert not await cloud.login()
+
+    async def test_msmartcloud_login_generic_error_returns_false(self) -> None:
+        """Test an unclassified error code keeps the old login() -> False contract."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            return_value=json.dumps({"code": 9999, "msg": "system error"}).encode(),
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "SmartHome",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert not await cloud.login()
+
+    def test_cloud_api_error_factory(self) -> None:
+        """Test cloud_api_error picks the most specific subclass per code."""
+        assert type(cloud_api_error(3201, "")) is NoDeviceRegistered
+        assert type(cloud_api_error(7610, "")) is CloudLoginError
+        assert type(cloud_api_error(65027, "")) is CloudLoginError
+        # unknown code falls back to the base class, and the meaning table
+        # enriches the string for known-but-generic codes
+        generic = cloud_api_error(9999, "system error")
+        assert type(generic) is MideaCloudError
+        assert "transient" in str(generic)
+        assert cloud_api_error(4242, "boom").code == 4242
+
+    async def test_msmartcloud_get_cloud_keys_no_paired_device(self) -> None:
+        """Test get_cloud_keys raises NoDeviceRegistered on a permission error.
+
+        The SmartHome cloud answers getToken with code 3201 when the account
+        does not own the appliance, which must surface as a specific error so
+        callers can tell the user to use the account that paired the device.
+        """
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["msmartcloud_reroute.json"],
+                self.responses["cloud_login_id.json"],
+                self.responses["msmartcloud_login.json"],
+                self.responses["cloud_no_permission.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "SmartHome",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+        assert await cloud.login()
+
+        with pytest.raises(NoDeviceRegistered) as err:
+            await cloud.get_cloud_keys(100)
+        assert err.value.code == 3201
+        assert err.value.message == "You have no permissions."
+
+    async def test_msmartcloud_get_cloud_keys_other_error_returns_empty(self) -> None:
+        """Test get_cloud_keys swallows non-permission errors and returns no keys."""
+        session = Mock()
+        response = Mock()
+        response.read = AsyncMock(
+            side_effect=[
+                self.responses["msmartcloud_reroute.json"],
+                self.responses["cloud_login_id.json"],
+                self.responses["msmartcloud_login.json"],
+                self.responses["cloud_invalid_response.json"],
+                self.responses["cloud_invalid_response.json"],
+            ],
+        )
+        session.request = AsyncMock(return_value=response)
+        cloud = get_midea_cloud(
+            "SmartHome",
+            session=session,
+            account="account",
+            password="password",
+        )
+        assert cloud is not None
+        assert await cloud.login()
+
+        assert await cloud.get_cloud_keys(100) == {}
 
     async def test_msmartcloud_list_home(self) -> None:
         """Test MSmartCloud list_home."""

--- a/tests/responses/cloud_no_permission.json
+++ b/tests/responses/cloud_no_permission.json
@@ -1,0 +1,4 @@
+{
+  "code": "3201",
+  "msg": "You have no permissions."
+}


### PR DESCRIPTION
The cloud API returns documented error codes that midea-local swallowed: 

- `_api_request()` -> `None`
- `get_cloud_keys()` -> `{}`
- `login()` -> `False`

so callers could only show a generic failure.

Table with details:

| Code | Message | Meaning |
|---|---|---|
| **3004** | `value is illegal` | Malformed/rejected `getToken` request (bad `udpid`/`applianceCodes`, or endpoint disabled on that cloud) |
| **3102** | Account or password incorrect, please re-enter | Login step |
| **3144** | login failed, loginId is empty, please login again | Login step |
| **3201** | `You have no permissions.` | Account authenticated successfully, but has no permission for this specific device — device isn't registered/bound to the account used for the call (e.g. a preset/shared account vs. the device's actual owner account) |
| **7610** | Too many failed login attempts, please try again 5 minutes later | Login step, rate-limit |
| **9999** | `system error` | Generic/transient cloud failure |
| **65027** | max simultaneous logged-in devices exceeded | Login step |
