### PR TITLE
fix(cloud): retry transient 9999 system error responses

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import time
-from asyncio import Lock
+from asyncio import Lock, sleep
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from hashlib import md5
@@ -23,6 +23,7 @@ from midealocal.exceptions import (
     CLOUD_ERROR_MEANINGS,
     LOGIN_ERROR_CODES,
     NO_PERMISSION_CODES,
+    TRANSIENT_CLOUD_ERROR_CODES,
     ElementMissing,
     cloud_api_error,
 )
@@ -39,6 +40,12 @@ SN8_MIN_SERIAL_LENGTH = 17
 # Cloud error codes that have a dedicated, actionable exception subclass; every
 # other non-zero code is logged and surfaced as ``None``.
 RAISE_FOR_ERROR_CODES = NO_PERMISSION_CODES | LOGIN_ERROR_CODES
+
+# Total attempts for a single cloud API call before giving up.
+_RETRY_ATTEMPTS = 3
+
+# Base delay between retries of a transient cloud error, scaled by attempt.
+_TRANSIENT_RETRY_BACKOFF_SECONDS = 1.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -252,7 +259,7 @@ class MideaCloud:
         if self._access_token is not None:
             header.update({"accessToken": self._access_token})
         response: dict = {"code": -1}
-        for _ in range(3):
+        for attempt in range(_RETRY_ATTEMPTS):
             try:
                 async with self._api_lock:
                     r = await self._session.request(
@@ -270,13 +277,15 @@ class MideaCloud:
                         _redact_data(str(raw)),
                     )
                     response = json.loads(raw)
-                    break
             except (TimeoutError, ClientConnectionError, json.JSONDecodeError) as e:
                 _LOGGER.warning(
                     "Midea cloud API error, url: %s, error: %s",
                     url,
                     repr(e),
                 )
+                continue
+            if not await self._retry_if_transient(url, int(response["code"]), attempt):
+                break
         code = int(response["code"])
         if code == 0 and "data" in response:
             return cast("dict", response["data"])
@@ -312,6 +321,26 @@ class MideaCloud:
         )
         if raise_for_error and code in RAISE_FOR_ERROR_CODES:
             raise cloud_api_error(code, message)
+
+    async def _retry_if_transient(self, url: str, code: int, attempt: int) -> bool:
+        """Return whether ``code`` is a transient error worth resending.
+
+        9999 "system error" comes back sporadically for otherwise valid calls;
+        a short back-off and resend usually succeeds. When retries remain this
+        waits and returns True so the caller loops again; otherwise the code is
+        left in ``response`` to be surfaced by ``_handle_error_code``.
+        """
+        if code not in TRANSIENT_CLOUD_ERROR_CODES or attempt >= _RETRY_ATTEMPTS - 1:
+            return False
+        _LOGGER.warning(
+            "Midea cloud API url: %s returned transient error %s; retry %s of %s",
+            url,
+            code,
+            attempt + 1,
+            _RETRY_ATTEMPTS - 1,
+        )
+        await sleep(_TRANSIENT_RETRY_BACKOFF_SECONDS * (attempt + 1))
+        return True
 
     async def _get_login_id(self) -> str | None:
         data = self._make_general_data()
@@ -1065,7 +1094,7 @@ class MideaAirCloud(MideaCloud):
         if self._access_token is not None:
             header.update({"accessToken": self._access_token})
         response: dict = {"errorCode": -1}
-        for _ in range(3):
+        for attempt in range(_RETRY_ATTEMPTS):
             try:
                 async with self._api_lock:
                     r = await self._session.request(
@@ -1083,13 +1112,19 @@ class MideaAirCloud(MideaCloud):
                         raw,
                     )
                     response = json.loads(raw)
-                    break
             except (TimeoutError, ClientConnectionError, json.JSONDecodeError) as e:
                 _LOGGER.warning(
                     "Midea cloud API error, url: %s, error: %s",
                     url,
                     repr(e),
                 )
+                continue
+            if not await self._retry_if_transient(
+                url,
+                int(response["errorCode"]),
+                attempt,
+            ):
+                break
         error_code = int(response["errorCode"])
         if error_code == 0:
             if "result" in response:

--- a/midealocal/exceptions.py
+++ b/midealocal/exceptions.py
@@ -67,6 +67,12 @@ CLOUD_ERROR_MEANINGS: dict[int, str] = {
 # account). See https://github.com/mill1000/midea-ac-py/issues/482.
 NO_PERMISSION_CODES = frozenset({3201})
 
+# Sporadic server-side failures that a plain resend usually clears: 9999
+# "system error" comes back for otherwise valid login / getToken calls on both
+# the legacy mapp.appsmb.com backend and the v5 proxy. midea-beautiful-air
+# likewise treats 9999 as ignore-and-retry (see its ``handle_api_error``).
+TRANSIENT_CLOUD_ERROR_CODES = frozenset({9999})
+
 # Failures of the login / loginId step that a user has to act on (wrong
 # credentials, expired session, rate limit, device-count limit).
 LOGIN_ERROR_CODES = frozenset({3102, 3144, 7610, 65027})

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,6 +14,7 @@ import pytest
 from aiohttp import ClientConnectionError
 
 from midealocal.cloud import (
+    _RETRY_ATTEMPTS,
     DEFAULT_KEYS,
     MeijuCloud,
     MideaAirCloud,
@@ -81,6 +82,18 @@ _TOSHIBA_ENCRYPTED_SN = (
 )
 _TOSHIBA_EXPECTED_SN = "0008AC0000000000000000000000BEEF"
 
+# 9999 "system error": a well-formed body that must be retried in place. Two
+# spellings so the same value works for the v5 proxy ("code") and the legacy
+# mapp.appsmb.com backend ("errorCode").
+_SYSTEM_ERROR_9999 = json.dumps({"code": 9999, "errorCode": 9999}).encode()
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff() -> Iterator[None]:
+    """Drop the transient-retry back-off so retry paths run without waiting."""
+    with patch("midealocal.cloud.sleep", new=AsyncMock()):
+        yield
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -121,26 +134,45 @@ async def test_msmartcloud_login_raises_cloud_login_error(code: int, msg: str) -
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("read_side_effect", "warns_rejected"),
+    ("cloud_name", "read_side_effect", "warns_rejected"),
     [
         pytest.param(
+            "SmartHome",
             [_RESPONSES["cloud_invalid_response.json"]] * 2,
             True,
             id="unclassified-code",
         ),
         pytest.param(
-            [json.dumps({"code": 9999, "msg": "system error"}).encode()] * 2,
+            "SmartHome",
+            # re_route and login/id each burn a full retry budget on 9999.
+            [_SYSTEM_ERROR_9999] * (_RETRY_ATTEMPTS * 2),
             True,
-            id="system-error-9999",
+            id="system-error-9999-v5-proxy",
         ),
         pytest.param(
+            "Midea Air",
+            # A 9999 that never clears must exhaust the legacy backend's retries
+            # and then surface, not loop forever.
+            [_SYSTEM_ERROR_9999] * _RETRY_ATTEMPTS,
+            True,
+            id="system-error-9999-legacy-appsmb",
+        ),
+        pytest.param(
+            "SmartHome",
             [_RESPONSES["msmartcloud_reroute.json"], *[ClientConnectionError()] * 3],
             False,
             id="unreachable",
         ),
+        pytest.param(
+            "Midea Air",
+            [ClientConnectionError()] * _RETRY_ATTEMPTS,
+            False,
+            id="unreachable-legacy-appsmb",
+        ),
     ],
 )
-async def test_msmartcloud_login_returns_false(
+async def test_login_returns_false(
+    cloud_name: str,
     read_side_effect: list,
     warns_rejected: bool,
     caplog: pytest.LogCaptureFixture,
@@ -156,7 +188,7 @@ async def test_msmartcloud_login_returns_false(
     response.read = AsyncMock(side_effect=read_side_effect)
     session.request = AsyncMock(return_value=response)
     cloud = get_midea_cloud(
-        "SmartHome",
+        cloud_name,
         session=session,
         account="account",
         password="password",
@@ -164,6 +196,59 @@ async def test_msmartcloud_login_returns_false(
     with caplog.at_level(logging.WARNING, logger="midealocal.cloud"):
         assert not await cloud.login()
     assert ("rejected the request" in caplog.text) is warns_rejected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cloud_name", "reads"),
+    [
+        pytest.param(
+            "SmartHome",
+            [
+                "msmartcloud_reroute.json",
+                _SYSTEM_ERROR_9999,
+                "cloud_login_id.json",
+                "msmartcloud_login.json",
+            ],
+            id="v5-proxy",
+        ),
+        pytest.param(
+            "Midea Air",
+            [
+                "mideaaircloud_login_id.json",
+                _SYSTEM_ERROR_9999,
+                "mideaaircloud_login.json",
+            ],
+            id="legacy-appsmb",
+        ),
+    ],
+)
+async def test_login_retries_transient_system_error(
+    cloud_name: str,
+    reads: list[str | bytes],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A single 9999 during login is resent and recovers.
+
+    The infamous "system error" is a sporadic server fault; midea-beautiful-air
+    likewise retries it rather than failing the login.
+    """
+    session = Mock()
+    response = Mock()
+    response.read = AsyncMock(
+        side_effect=[r if isinstance(r, bytes) else _RESPONSES[r] for r in reads],
+    )
+    session.request = AsyncMock(return_value=response)
+    cloud = get_midea_cloud(
+        cloud_name,
+        session=session,
+        account="account",
+        password="password",
+    )
+    with caplog.at_level(logging.WARNING, logger="midealocal.cloud"):
+        assert await cloud.login()
+    assert "transient error 9999" in caplog.text
+    assert "rejected the request" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug Fixes
  * Cloud requests now automatically retry after transient system errors, including error code 9999.
  * Improved resilience during login across supported cloud backends, reducing failures caused by temporary service issues.
  * Retry attempts use a controlled backoff and retry limit before reporting failure.