### PR TITLE
feat(cloud): classify 3101/3106/3301 as login errors

### DIFF
--- a/midealocal/exceptions.py
+++ b/midealocal/exceptions.py
@@ -43,10 +43,11 @@ class ValueWrongType(MideaLocalError):
     """Exception raised when the value has a wrong data type."""
 
 
-# Verified against mp-prod.appsmb.com. The wire message text varies by locale
-# and endpoint (65027 comes back in Chinese), so callers should branch on the
-# code; the meaning here is only for logging.
+# Seen on mp-prod.appsmb.com and the Meiju gateway (1002 / 40404). The wire
+# message text varies by locale and endpoint (65027 comes back in Chinese), so
+# callers should branch on the code; the meaning here is only for logging.
 CLOUD_ERROR_MEANINGS: dict[int, str] = {
+    1002: "a required request parameter is missing or has the wrong type",
     3004: (
         "malformed or rejected request: bad udpid/applianceCodes, or the "
         "endpoint is disabled on this cloud"
@@ -62,6 +63,7 @@ CLOUD_ERROR_MEANINGS: dict[int, str] = {
     3301: "invalid app key for this cloud",
     7610: "too many failed login attempts; locked for about 5 minutes",
     9999: "generic or transient cloud error",
+    40404: "the API endpoint does not exist; it was retired or moved",
     65027: "maximum number of simultaneously logged-in devices exceeded",
 }
 

--- a/midealocal/exceptions.py
+++ b/midealocal/exceptions.py
@@ -51,12 +51,15 @@ CLOUD_ERROR_MEANINGS: dict[int, str] = {
         "malformed or rejected request: bad udpid/applianceCodes, or the "
         "endpoint is disabled on this cloud"
     ),
+    3101: "account password is incorrect",
     3102: "account or password incorrect",
+    3106: "login session is invalid; log in again",
     3144: "login session is no longer valid (empty loginId); log in again",
     3201: (
         "the account has no permission for this device; it is bound to a "
         "different account"
     ),
+    3301: "invalid app key for this cloud",
     7610: "too many failed login attempts; locked for about 5 minutes",
     9999: "generic or transient cloud error",
     65027: "maximum number of simultaneously logged-in devices exceeded",
@@ -68,8 +71,10 @@ CLOUD_ERROR_MEANINGS: dict[int, str] = {
 NO_PERMISSION_CODES = frozenset({3201})
 
 # Failures of the login / loginId step that a user has to act on (wrong
-# credentials, expired session, rate limit, device-count limit).
-LOGIN_ERROR_CODES = frozenset({3102, 3144, 7610, 65027})
+# credentials, invalid app key, expired session, rate limit, device-count
+# limit). 3101/3102 wrong password/account, 3301 wrong app key, 3106/3144
+# dead session -- all reported by nbogojevic/midea-beautiful-air.
+LOGIN_ERROR_CODES = frozenset({3101, 3102, 3106, 3144, 3301, 7610, 65027})
 
 
 class MideaCloudError(MideaLocalError):

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -86,8 +86,11 @@ _TOSHIBA_EXPECTED_SN = "0008AC0000000000000000000000BEEF"
 @pytest.mark.parametrize(
     ("code", "msg"),
     [
+        (3101, "password error"),
         (3102, "Account or password incorrect, please re-enter"),
+        (3106, "invalid session"),
         (3144, "login failed, loginId is empty, please login again"),
+        (3301, "app key is invalid"),
         (7610, "Too many failed login attempts, please try again 5 minutes later"),
         (65027, "该用户在线登录设备已超过上限,请更换账号登录"),
     ],
@@ -95,9 +98,9 @@ _TOSHIBA_EXPECTED_SN = "0008AC0000000000000000000000BEEF"
 async def test_msmartcloud_login_raises_cloud_login_error(code: int, msg: str) -> None:
     """Test known login-step error codes surface as CloudLoginError.
 
-    3102/3144/7610/65027 are actionable failures of the login / loginId step;
-    callers need the code to show the right message, so login() must raise
-    rather than return a bare False.
+    3101/3102/3106/3144/3301/7610/65027 are actionable failures of the login /
+    loginId step; callers need the code to show the right message, so login()
+    must raise rather than return a bare False.
     """
     session = Mock()
     response = Mock()
@@ -842,6 +845,9 @@ class CloudTest(IsolatedAsyncioTestCase):
     def test_cloud_api_error_factory(self) -> None:
         """Test cloud_api_error picks the most specific subclass per code."""
         assert type(cloud_api_error(3201, "")) is NoDeviceRegistered
+        assert type(cloud_api_error(3101, "")) is CloudLoginError
+        assert type(cloud_api_error(3106, "")) is CloudLoginError
+        assert type(cloud_api_error(3301, "")) is CloudLoginError
         assert type(cloud_api_error(7610, "")) is CloudLoginError
         assert type(cloud_api_error(65027, "")) is CloudLoginError
         # unknown code falls back to the base class, and the meaning table

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -856,6 +856,10 @@ class CloudTest(IsolatedAsyncioTestCase):
         assert type(generic) is MideaCloudError
         assert "transient" in str(generic)
         assert cloud_api_error(4242, "boom").code == 4242
+        # getToken-only codes: base class, but still enriched from the table
+        assert type(cloud_api_error(1002, "")) is MideaCloudError
+        assert "parameter" in str(cloud_api_error(1002, ""))
+        assert "retired" in str(cloud_api_error(40404, ""))
 
     async def test_msmartcloud_list_home(self) -> None:
         """Test MSmartCloud list_home."""


### PR DESCRIPTION
## Bug Fixes
* Improved cloud login error handling for incorrect passwords, invalid login sessions, and invalid app keys.
* These errors are now consistently reported as login failures.