### PR TITLE
feat: add OS Comfort (Olimpia Splendid) cloud

### DIFF
--- a/midealocal/cloud.py
+++ b/midealocal/cloud.py
@@ -85,6 +85,12 @@ SUPPORTED_CLOUDS: dict[str, Any] = {
         "app_key": "434a209a5ce141c3b726de067835d7f0",
         "api_url": "https://mapp.appsmb.com",  # codespell:ignore
     },
+    "OS Comfort": {
+        "class_name": "MideaAirCloud",
+        "app_id": "1114",
+        "app_key": "02021a881e4d4b21d7fed806719e5440",
+        "api_url": "https://mapp.appsmb.com",  # codespell:ignore
+    },
     "Toshiba Iolife": {
         "class_name": "ToshibaIOLife",
         "app_id": "1203",

--- a/tests/cloud_test.py
+++ b/tests/cloud_test.py
@@ -246,6 +246,10 @@ class CloudTest(IsolatedAsyncioTestCase):
             get_midea_cloud("Ariston Clima", session, "", ""),
             MideaAirCloud,
         )
+        assert isinstance(
+            get_midea_cloud("OS Comfort", session, "", ""),
+            MideaAirCloud,
+        )
         with pytest.raises(ElementMissing):
             get_midea_cloud("Invalid", session, "", "")
 
@@ -338,7 +342,7 @@ class CloudTest(IsolatedAsyncioTestCase):
     async def test_get_cloud_servers(self) -> None:
         """Test get cloud servers."""
         servers = await MideaCloud.get_cloud_servers()
-        assert len(servers.items()) == 6
+        assert len(servers.items()) == 7
 
     async def test_get_preset_account_cloud(self) -> None:
         """Test get preset cloud account."""


### PR DESCRIPTION
## New Features
  - Added support for connecting to the OS Comfort cloud service.

## Tests
  - Added coverage verifying OS Comfort connections.
  - Updated cloud server coverage for the expanded list of supported services.