### PR TITLE
feat(a1): expose device capabilities

### DIFF
--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -81,7 +81,7 @@ class MideaA1Device(MideaDevice):
                 DeviceAttributes.filter_cleaning_reminder: False,
             },
         )
-        self._pump_enable = False
+        self._capabilities: dict[str, bool] = {}
         self._speeds = self._default_speeds
         self._modes = self._default_modes
         self.set_customize(customize)
@@ -102,9 +102,9 @@ class MideaA1Device(MideaDevice):
         return MideaA1Device._water_level_sets
 
     @property
-    def pump_supported(self) -> bool:
-        """Return whether the device supports a pump."""
-        return self._pump_enable
+    def capabilities(self) -> dict[str, bool]:
+        """Return the capabilities reported by the device."""
+        return self._capabilities
 
     def build_query(self) -> list[MessageQuery]:
         """Midea A1 device build query."""
@@ -114,9 +114,10 @@ class MideaA1Device(MideaDevice):
         """Midea A1 device process message."""
         message = MessageA1Response(bytearray(msg))
         self._message_protocol_version = message.protocol_version
-        # Preserve the hidden pump capability bit for future set packets.
+        # Preserve the pump capability bit for future set packets and expose it
+        # through the capability map.
         if hasattr(message, "pump_enable"):
-            self._pump_enable = message.pump_enable
+            self._capabilities["pump"] = message.pump_enable
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         new_status = self.update_attributes_from_message(
             message,
@@ -135,6 +136,7 @@ class MideaA1Device(MideaDevice):
             if self._attributes[DeviceAttributes.tank_full] != tank_full_calculated:
                 self._attributes[DeviceAttributes.tank_full] = tank_full_calculated
                 new_status[DeviceAttributes.tank_full.value] = tank_full_calculated
+        new_status["capabilities"] = dict(self._capabilities)
         return new_status
 
     def make_message_set(self) -> MessageSet:
@@ -159,7 +161,7 @@ class MideaA1Device(MideaDevice):
         message.swing = self._attributes[DeviceAttributes.swing]
         message.anion = self._attributes[DeviceAttributes.anion]
         message.pump = self._attributes[DeviceAttributes.pump]
-        message.pump_enable = self._pump_enable
+        message.pump_enable = self._capabilities.get("pump", False)
         message.water_level_set = int(
             self._attributes[DeviceAttributes.water_level_set],
         )

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -104,7 +104,7 @@ class MideaA1Device(MideaDevice):
     @property
     def capabilities(self) -> dict[str, bool]:
         """Return the capabilities reported by the device."""
-        return self._capabilities
+        return dict(self._capabilities)
 
     def build_query(self) -> list[MessageQuery]:
         """Midea A1 device build query."""

--- a/midealocal/devices/a1/__init__.py
+++ b/midealocal/devices/a1/__init__.py
@@ -101,6 +101,11 @@ class MideaA1Device(MideaDevice):
         """Midea A1 device water level options."""
         return MideaA1Device._water_level_sets
 
+    @property
+    def pump_supported(self) -> bool:
+        """Return whether the device supports a pump."""
+        return self._pump_enable
+
     def build_query(self) -> list[MessageQuery]:
         """Midea A1 device build query."""
         return [MessageQuery(self._message_protocol_version)]

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -83,7 +83,7 @@ class TestMideaA1Device:
             assert new_status[DeviceAttributes.pump.value]
             assert new_status[DeviceAttributes.tank_full.value]
             assert new_status[DeviceAttributes.mode.value] == "manual"
-            assert self.device.pump_supported
+            assert self.device.capabilities == {"pump": True}
 
             mock_message.mode = 10
             mock_message.fan_speed = 99
@@ -93,7 +93,7 @@ class TestMideaA1Device:
             assert new_status[DeviceAttributes.mode.value] is None
             assert new_status[DeviceAttributes.fan_speed.value] is None
             assert not new_status[DeviceAttributes.tank_full.value]
-            assert not self.device.pump_supported
+            assert self.device.capabilities == {"pump": False}
 
     def test_build_query(self) -> None:
         """Test build query."""

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -83,14 +83,17 @@ class TestMideaA1Device:
             assert new_status[DeviceAttributes.pump.value]
             assert new_status[DeviceAttributes.tank_full.value]
             assert new_status[DeviceAttributes.mode.value] == "manual"
+            assert self.device.pump_supported
 
             mock_message.mode = 10
             mock_message.fan_speed = 99
+            mock_message.pump_enable = False
             mock_message.tank = 30
             new_status = self.device.process_message(b"")
             assert new_status[DeviceAttributes.mode.value] is None
             assert new_status[DeviceAttributes.fan_speed.value] is None
             assert not new_status[DeviceAttributes.tank_full.value]
+            assert not self.device.pump_supported
 
     def test_build_query(self) -> None:
         """Test build query."""

--- a/tests/devices/a1/device_a1_test.py
+++ b/tests/devices/a1/device_a1_test.py
@@ -85,6 +85,10 @@ class TestMideaA1Device:
             assert new_status[DeviceAttributes.mode.value] == "manual"
             assert self.device.capabilities == {"pump": True}
 
+            capabilities = self.device.capabilities
+            capabilities["pump"] = False
+            assert self.device.capabilities == {"pump": True}
+
             mock_message.mode = 10
             mock_message.fan_speed = 99
             mock_message.pump_enable = False


### PR DESCRIPTION
## Summary

Expose A1 device capabilities through a public capability map.

The A1 protocol already provides a `pump_enable` capability bit separately from the current `pump` state. This change exposes that existing signal through `device.capabilities["pump"]`, following the capability-reporting pattern used by other device implementations.

This supports [Home Assistant core PR #181257](https://github.com/home-assistant/core/pull/181257), which needs to create the A1 pump switch only for devices that report pump support.

## Testing

Added focused A1 device coverage verifying that the capability map reflects both supported and unsupported pump capability states reported by the device.

## Notes

Reference implementation: [midea-local PR #746](https://github.com/midea-lan/midea-local/pull/746)
