### PR TITLE
fix(ac): default values for make message set when missing DeviceAttributes

### DIFF
--- a/midealocal/devices/ac/__init__.py
+++ b/midealocal/devices/ac/__init__.py
@@ -578,27 +578,49 @@ class MideaACDevice(MideaDevice):
     def make_message_set(self) -> MessageGeneralSet:
         """Midea AC device make message set."""
         message = MessageGeneralSet(self._message_protocol_version)
-        message.power = self._attributes[DeviceAttributes.power]
-        message.prompt_tone = self._attributes[DeviceAttributes.prompt_tone]
-        message.mode = self._attributes[DeviceAttributes.mode]
-        message.target_temperature = self._attributes[
-            DeviceAttributes.target_temperature
-        ]
-        message.fan_speed = self._attributes[DeviceAttributes.fan_speed]
-        message.swing_vertical = self._attributes[DeviceAttributes.swing_vertical]
-        message.swing_horizontal = self._attributes[DeviceAttributes.swing_horizontal]
-        message.boost_mode = self._attributes[DeviceAttributes.boost_mode]
-        message.power_saving = self._attributes[DeviceAttributes.power_saving]
-        message.smart_eye = self._attributes[DeviceAttributes.smart_eye]
-        message.dry = self._attributes[DeviceAttributes.dry]
-        message.eco_mode = self._attributes[DeviceAttributes.eco_mode]
-        message.aux_heating = self._attributes[DeviceAttributes.aux_heating]
-        message.sleep_mode = self._attributes[DeviceAttributes.sleep_mode]
-        message.natural_wind = self._attributes[DeviceAttributes.natural_wind]
-        message.temp_fahrenheit = self._attributes[DeviceAttributes.temp_fahrenheit]
-        message.frost_protect = self._attributes[DeviceAttributes.frost_protect]
-        message.comfort_mode = self._attributes[DeviceAttributes.comfort_mode]
-        message.anion = self._attributes[DeviceAttributes.anion]
+        message.power = self._attributes.get(DeviceAttributes.power, False)
+        message.prompt_tone = self._attributes.get(DeviceAttributes.prompt_tone, True)
+        message.mode = self._attributes.get(DeviceAttributes.mode, 0)
+        message.target_temperature = self._attributes.get(
+            DeviceAttributes.target_temperature,
+            20.0,
+        )
+        message.fan_speed = self._attributes.get(DeviceAttributes.fan_speed, 102)
+        message.swing_vertical = self._attributes.get(
+            DeviceAttributes.swing_vertical,
+            False,
+        )
+        message.swing_horizontal = self._attributes.get(
+            DeviceAttributes.swing_horizontal,
+            False,
+        )
+        message.boost_mode = self._attributes.get(DeviceAttributes.boost_mode, False)
+        message.power_saving = self._attributes.get(
+            DeviceAttributes.power_saving,
+            False,
+        )
+        message.smart_eye = self._attributes.get(DeviceAttributes.smart_eye, False)
+        message.dry = self._attributes.get(DeviceAttributes.dry, False)
+        message.aux_heating = self._attributes.get(DeviceAttributes.aux_heating, False)
+        message.eco_mode = self._attributes.get(DeviceAttributes.eco_mode, False)
+        message.temp_fahrenheit = self._attributes.get(
+            DeviceAttributes.temp_fahrenheit,
+            False,
+        )
+        message.sleep_mode = self._attributes.get(DeviceAttributes.sleep_mode, False)
+        message.natural_wind = self._attributes.get(
+            DeviceAttributes.natural_wind,
+            False,
+        )
+        message.frost_protect = self._attributes.get(
+            DeviceAttributes.frost_protect,
+            False,
+        )
+        message.comfort_mode = self._attributes.get(
+            DeviceAttributes.comfort_mode,
+            False,
+        )
+        message.anion = self._attributes.get(DeviceAttributes.anion, False)
         return message
 
     def make_newprotocol_message_set(

--- a/tests/devices/ac/device_ac_test.py
+++ b/tests/devices/ac/device_ac_test.py
@@ -1025,3 +1025,52 @@ class TestMideaACDevice:
     def test_invalid_customize_format(self) -> None:
         """Test invalid customize format."""
         self.device.set_customize("{")
+
+    def test_make_message_set_with_missing_attrs(self) -> None:
+        """Test make message set with attributes removed from the device."""
+        message = self.device.make_message_set()
+        assert not message.anion
+
+        with patch("midealocal.devices.ac.MessageACResponse") as mock_message_response:
+            mock_message = mock_message_response.return_value
+            mock_message.anion = True
+            mock_message.prompt_tone = False
+            mock_message.power = True
+            mock_message.mode = 1
+            mock_message.target_temperature = 25.0
+            mock_message.fan_speed = 102
+            mock_message.swing_vertical = True
+            mock_message.swing_horizontal = True
+            mock_message.smart_eye = True
+            mock_message.dry = True
+            mock_message.aux_heating = True
+            mock_message.boost_mode = True
+            mock_message.power_saving = True
+            mock_message.sleep_mode = True
+            mock_message.frost_protect = True
+            mock_message.comfort_mode = True
+            mock_message.eco_mode = True
+            mock_message.natural_wind = True
+            mock_message.temp_fahrenheit = True
+            mock_message.screen_display = True
+            mock_message.screen_display_alternate = True
+            mock_message.full_dust = True
+            mock_message.indoor_temperature = None
+            mock_message.outdoor_temperature = None
+            mock_message.indoor_humidity = None
+            mock_message.breezeless = True
+            mock_message.total_energy_consumption = None
+            mock_message.current_energy_consumption = None
+            mock_message.realtime_power = None
+            mock_message.fresh_air_power = True
+            mock_message.fresh_air_fan_speed = 0
+            mock_message.fresh_air_1 = 1
+            mock_message.fresh_air_2 = 1
+            mock_message.out_silent = True
+            self.device.process_message(b"")
+
+        message = self.device.make_message_set()
+        assert message.anion
+        self.device._attributes.pop(DeviceAttributes.anion)
+        message = self.device.make_message_set()
+        assert not message.anion


### PR DESCRIPTION
After removing attributes from devices based on capabilities, the make_message_set will fail. Eg. anion support.

Follow-up for https://github.com/midea-lan/midea-local/pull/728