### PR TITLE
feat(b8): support the second-generation ("750004CE") protocol

### DIFF
--- a/midealocal/devices/b8/__init__.py
+++ b/midealocal/devices/b8/__init__.py
@@ -25,8 +25,32 @@ from .message import (
     MessageSet,
     MessageSetCommand,
 )
+from .message_v2 import (
+    B8V2ConfigType,
+    B8V2FanLevel,
+    B8V2TaskControl,
+    B8V2WaterLevel,
+    MessageB8V2Response,
+    MessageV2Query,
+    MessageV2SetCommand,
+    MessageV2SetConfig,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Integer ``subType`` (Midea cloud API) of B8 models that speak the
+# second-generation protocol (cloud plugin SN8 "750004CE"); see message_v2.py.
+# Empty until a real device's subType is known -- it cannot be derived from the
+# plugin, so v2 support stays inert until an entry is added here.
+_V2_SUBTYPES: frozenset[int] = frozenset()
+
+# v1 start/stop/charge/pause command -> v2 task-control code.
+_WORK_MODE_TO_V2_TASK: dict[B8WorkMode, B8V2TaskControl] = {
+    B8WorkMode.CHARGE: B8V2TaskControl.CHARGE,
+    B8WorkMode.WORK: B8V2TaskControl.WORK,
+    B8WorkMode.STOP: B8V2TaskControl.STOP,
+    B8WorkMode.PAUSE: B8V2TaskControl.PAUSE,
+}
 
 
 def _translate_int_enum(v: Any) -> Any:  # noqa: ANN401
@@ -37,6 +61,8 @@ class DeviceAttributes(StrEnum):
     """Midea B8 device attributes."""
 
     work_status = "work_status"
+    sub_work_status = "sub_work_status"
+    sweep_mop_mode = "sweep_mop_mode"
     function_type = "function_type"
     control_type = "control_type"
     move_direction = "move_direction"
@@ -78,6 +104,9 @@ class MideaB8Device(MideaDevice):
             **kwargs,
             attributes={
                 DeviceAttributes.work_status: B8WorkStatus.NONE.name.lower(),
+                # v2-only; stays "none" on v1 devices
+                DeviceAttributes.sub_work_status: "none",
+                DeviceAttributes.sweep_mop_mode: "none",
                 DeviceAttributes.function_type: B8FunctionType.NONE.name.lower(),
                 DeviceAttributes.control_type: B8ControlType.NONE.name.lower(),
                 DeviceAttributes.move_direction: B8Moviment.NONE.name.lower(),
@@ -105,13 +134,22 @@ class MideaB8Device(MideaDevice):
             },
         )
 
-    def build_query(self) -> list[MessageQuery]:
+    @property
+    def _is_v2(self) -> bool:
+        """Whether this device speaks the second-generation B8 protocol."""
+        return self.subtype in _V2_SUBTYPES
+
+    def build_query(self) -> list[MessageQuery | MessageV2Query]:
         """Midea B8 device build query."""
+        if self._is_v2:
+            return [MessageV2Query(self._message_protocol_version)]
         return [MessageQuery(self._message_protocol_version)]
 
     def process_message(self, msg: bytes) -> dict[str, Any]:
         """Midea B8 device process message."""
-        message = MessageB8Response(msg)
+        message: MessageB8Response | MessageB8V2Response = (
+            MessageB8V2Response(msg) if self._is_v2 else MessageB8Response(msg)
+        )
         _LOGGER.debug("[%s] Received: %s", self.device_id, message)
         # lowercase name for IntEnums, pass through everything else unchanged
         return self.update_attributes_from_message(
@@ -133,6 +171,16 @@ class MideaB8Device(MideaDevice):
 
     def set_work_mode(self, work_mode: B8WorkMode) -> None:
         """Midea B8 device set work mode."""
+        if self._is_v2:
+            task = _WORK_MODE_TO_V2_TASK.get(work_mode)
+            if task is None:
+                _LOGGER.warning("Unsupported v2 work mode: %s", work_mode)
+                return
+            self.build_send(
+                MessageV2SetCommand(self._message_protocol_version, task),
+            )
+            return
+
         if work_mode == B8WorkMode.WORK:
             self.set_attribute(
                 DeviceAttributes.clean_mode,
@@ -143,8 +191,39 @@ class MideaB8Device(MideaDevice):
         msg = MessageSetCommand(self._message_protocol_version, work_mode=work_mode)
         self.build_send(msg)
 
+    def _set_attribute_v2(self, attr: str, value: bool | float | str) -> None:
+        """Midea B8 v2 device set attribute (one frame per setting)."""
+        try:
+            if attr == DeviceAttributes.fan_level:
+                msg: MessageV2SetConfig = MessageV2SetConfig(
+                    self._message_protocol_version,
+                    B8V2ConfigType.FAN,
+                    B8V2FanLevel[str(value).upper()],
+                )
+            elif attr == DeviceAttributes.water_level:
+                msg = MessageV2SetConfig(
+                    self._message_protocol_version,
+                    B8V2ConfigType.WATER,
+                    B8V2WaterLevel[str(value).upper()],
+                )
+            elif attr == DeviceAttributes.voice_volume:
+                msg = MessageV2SetConfig(
+                    self._message_protocol_version,
+                    B8V2ConfigType.VOICE,
+                    max(1, min(int(value), 100)),
+                )
+            else:
+                _LOGGER.warning("Unsupported v2 attribute set: %s", attr)
+                return
+            self.build_send(msg)
+        except KeyError:
+            _LOGGER.exception("Wrong value for attribute %s: %s", attr, value)
+
     def set_attribute(self, attr: str, value: bool | float | str) -> None:
         """Midea B8 device set attribute."""
+        if self._is_v2:
+            self._set_attribute_v2(attr, value)
+            return
         try:
             msg = self._gen_set_msg_default_values()
             if attr == DeviceAttributes.clean_mode:

--- a/midealocal/devices/b8/message_v2.py
+++ b/midealocal/devices/b8/message_v2.py
@@ -1,0 +1,549 @@
+"""Midea local B8 second-generation ("v2") protocol messages.
+
+Newer B8 robot vacuums (Midea cloud plugin SN8 ``750004CE``, models with a
+base/wash station) speak a different wire protocol than the one in
+``message.py`` (SN8 ``7500001H``):
+
+* control/query/report frames use body-type ``0xAA`` followed by a version
+  byte ``0x01`` and a type selector, instead of body-type ``0x22``/``0x32``;
+* the work-status table is renumbered (``pause`` is ``clean_pause = 0x06``
+  here, ``0x08`` in v1, and the start/stop/pause *command* still uses the
+  legacy ``0x1B`` on its own channel);
+* start/stop/charge/pause go through a task-control channel
+  (``02 AA 01 01 <code>``) and each setting (fan, water, voice ...) is its
+  own ``02 AA 01 <selector> <value>`` frame;
+* ``sleep``/``relocate``/``on_base`` work states carry a sub-status byte.
+
+This module is a faithful port of ``lua/b8/T_0000_B8_750004CE_2024011101.lua``
+(``decode0401Report`` for field offsets -- ``decodeQueryWorkStatusBin`` in the
+same plugin is visibly buggy). It is selected per device in ``__init__.py``
+via ``_V2_SUBTYPES``.
+"""
+
+from enum import IntEnum
+
+from midealocal.const import DeviceType
+from midealocal.message import (
+    ListTypes,
+    MessageBody,
+    MessageRequest,
+    MessageResponse,
+    MessageType,
+)
+
+from .message import B8ControlType, B8ErrorType, B8MopState
+
+
+class B8V2WorkStatus(IntEnum):
+    """Midea B8 v2 work status."""
+
+    NONE = 0x00
+    CHARGING = 0x01
+    CHARGING_ON_DOCK = 0x02
+    CHARGE_PAUSE = 0x03
+    CHARGE_FINISH = 0x04
+    WORK = 0x05
+    CLEAN_PAUSE = 0x06
+    STOP = 0x07
+    UPDATING = 0x08
+    ERROR = 0x09
+    SLEEP = 0x0A
+    RELOCATE = 0x0B
+    MAP_SEARCHING = 0x0C
+    CLEAN_MOP = 0x0D
+    BACK_CLEAN_MOP = 0x0E
+    CLEAN_MOP_PAUSE = 0x0F
+    MANUAL_CONTROL = 0x11
+    ON_BASE = 0x12
+    VIDEO_CRUISE = 0x13
+    VIDEO_CRUISE_PAUSE = 0x14
+    MAP_SEARCHING_PAUSE = 0x15
+
+
+class B8V2SubWorkStatus(IntEnum):
+    """Midea B8 v2 sub work status (reported while ``ON_BASE``)."""
+
+    FREE = 0x00
+    CHARGING = 0x01
+    INJECT_WATER = 0x02
+    CLEAN_MOP = 0x03
+    DRY_MOP = 0x04
+    HOT_DRY_MOP = 0x05
+    WATER_STATION_ERROR = 0x06
+    CHARGE_FINISH = 0x07
+    ERP_MODE = 0x08
+    AUTO_CLEAN = 0x09
+    DUST_COLLECT = 0x0A
+    CUT_HAIR = 0x0B
+
+
+class B8V2SleepingStatus(IntEnum):
+    """Midea B8 v2 sub work status (reported while ``SLEEP``)."""
+
+    DEFAULT_SLEEPING = 0x30
+    PAUSE_SLEEPING = 0x31
+    STANDING_SLEEPING = 0x32
+    CHARGE_PAUSE_SLEEPING = 0x33
+    RETURN_STATION_PAUSE_SLEEPING = 0x34
+    CRUISE_PAUSE_SLEEPING = 0x35
+
+
+class B8V2RelocateReason(IntEnum):
+    """Midea B8 v2 sub work status (reported while ``RELOCATE``)."""
+
+    DEFAULT = 0x50
+    FIRST_START = 0x51
+    WHEEL_LIFT = 0x52
+    MILEMETER_DATA_CHANGE = 0x53
+    IMU_DATA_CHANGE = 0x54
+    NO_MAP = 0x55
+    COMING_OUT_DURING_RELOCATE = 0x56
+    MAP_CHANGE = 0x57
+    MANUAL_CONTROL = 0x58
+    POSITION_OUT_OF_MAP = 0x59
+
+
+class B8V2Moviment(IntEnum):
+    """Midea B8 v2 movement."""
+
+    NONE = 0x00
+    FORWARD = 0x01
+    BACK = 0x02
+    LEFT = 0x03
+    RIGHT = 0x04
+    FORWARD_LEFT = 0x05
+    FORWARD_RIGHT = 0x06
+    BACK_LEFT = 0x07
+    BACK_RIGHT = 0x08
+
+
+class B8V2CleanMode(IntEnum):
+    """Midea B8 v2 clean mode."""
+
+    NONE = 0x00
+    AUTO = 0x08
+    AREA = 0x09
+    ZONE_INDEX = 0x0A
+    ZONE_RECT = 0x0B
+    TARGET_POINT = 0x0D
+
+
+class B8V2FanLevel(IntEnum):
+    """Midea B8 v2 fan level."""
+
+    NORMAL = 0x01
+    HIGH = 0x02
+    SUPER = 0x03
+    SOFT = 0x04
+
+
+class B8V2WaterLevel(IntEnum):
+    """Midea B8 v2 water level."""
+
+    LOW = 0x01
+    NORMAL = 0x02
+    HIGH = 0x03
+
+
+class B8V2SpeakLevel(IntEnum):
+    """Midea B8 v2 voice level."""
+
+    NONE = 0x00
+    OFF = 0x01
+    LOW = 0x02
+    NORMAL = 0x03
+    HIGH = 0x04
+
+
+class B8V2SweepMopMode(IntEnum):
+    """Midea B8 v2 sweep/mop mode."""
+
+    SWEEP_AND_MOP = 0x00
+    SWEEP = 0x01
+    MOP = 0x02
+    SWEEP_THEN_MOP = 0x03
+
+
+class B8V2FunctionType(IntEnum):
+    """Midea B8 v2 function type."""
+
+    NONE = 0x00
+    DUST_BOX_CLEANING = 0x01
+    WATER_TANK_CLEANING = 0x02
+    RELOCATE_DEFAULT = 0x03
+    RELOCATE_IN_PROGRESS = 0x04
+    RELOCATE_SUCCESS = 0x05
+    RELOCATE_FAIL = 0x06
+
+
+class B8V2TaskControl(IntEnum):
+    """Midea B8 v2 task-control command (``02 AA 01 01 <code>``)."""
+
+    CHARGE = 0x01
+    CHARGE_PAUSE = 0x02
+    CHARGE_CONTINUE = 0x03
+    WORK = 0x04
+    PAUSE = 0x05
+    CONTINUE = 0x06
+    STOP = 0x07
+    VIDEO_CRUISE_START = 0x08
+    VIDEO_CRUISE_PAUSE = 0x09
+    QUICKLY_MAPPING = 0x0A
+
+
+class B8V2ConfigType(IntEnum):
+    """Midea B8 v2 per-setting selector byte (``02 AA 01 <selector> <value>``)."""
+
+    FAN = 0x50
+    WATER = 0x51
+    VOICE = 0x93
+
+
+class B8V2QueryType(IntEnum):
+    """Midea B8 v2 query selector byte (``03 AA 01 <selector>``)."""
+
+    WORK = 0x01
+
+
+class B8V2ErrorFixDescription(IntEnum):
+    """Midea B8 v2 fixable-error description."""
+
+    NO = 0x00
+    FIX_DUST = 0x01
+    FIX_WHEEL_HANG = 0x02
+    FIX_WHEEL_OVERLOAD = 0x03
+    FIX_SIDE_BRUSH_OVERLOAD = 0x04
+    FIX_ROLL_BRUSH_OVERLOAD = 0x05
+    FIX_DUST_ENGINE = 0x06
+    FIX_FRONT_PANEL = 0x07
+    FIX_RADAR_MASK = 0x08
+    FIX_DROP_SENSOR = 0x09
+    FIX_LOW_BATTERY = 0x0A
+    FIX_ABNORMAL_POSTURE = 0x0B
+    FIX_LASER_SENSOR = 0x0C
+    FIX_EDGE_SENSOR = 0x0D
+    FIX_START_IN_FORBID_AREA_1 = 0x0E
+    FIX_START_IN_STRONG_MAGNETIC = 0x0F
+    FIX_LASER_SENSOR_BLOCKED = 0x10
+    FIX_MOPPING_BOARD_DROPPED = 0x11
+    FIX_SLIPPING_AND_JAMMING = 0x12
+    FIX_MULTIPLE_RECHARGE_ATTEMPTS = 0x13
+    FIX_VIBRATION_DRAG_OVERLOAD = 0x14
+    FIX_WIPE_DISK_OVERLOAD = 0x15
+    FIX_WATER_TANK_MISS = 0x16
+    FIX_WIPE_DISK_CHIP_FAULT = 0x17
+    FIX_TEMPERATURE_TOO_HIGH = 0x18
+    FIX_HAIR_CUT_FAILED = 0x20
+    FIX_MOP_DROP_OUT = 0x40
+    FIX_ROTATE_TIME_OUT = 0x41
+    FIX_NO_BASE_STATION_IN_MAP = 0x42
+    FIX_IN_FORBID_AREA_OR_NO_BACK_ROUTE = 0x43
+    FIX_MAX_RETRY_TIMES_EXCEEDED = 0x44
+    FIX_AUTO_FIX_RADAR_HIGH_TEMPERATURE_FAILED = 0x45
+    FIX_REACH_DESTINATION_FAILED = 0x50
+    FIX_PHYSICAL_COLLISION_PLATE_OCCURRED = 0x51
+    FIX_START_IN_FORBID_VIRTUAL_AREA = 0x52
+    FIX_WHEEL_SUSPENSION = 0x53
+    FIX_OUT_STATION_FAILED = 0x54
+    FIX_ESCAPE_ENVIRONMENT_FAILED = 0x55
+    FIX_INNER_COMMUNICATION_TIMEOUT = 0x57
+    FIX_USE_SWEEP_AND_MOP_ON_CARPET = 0x58
+    FIX_START_IN_VIRTUAL_WALL = 0x59
+    FIX_START_IN_FORBID_AREA = 0x5A
+    FIX_START_IN_FORBID_WATER_AREA = 0x5B
+    FIX_START_IN_FORBID_AREA_2 = 0x5C
+    FIX_TRAPPED_IN_SMALL_AREA = 0x5D
+    FIX_WHOLE_HOUSE_CLEAN_WITH_WRONG_PARTITION = 0x5E
+    FIX_RADAR_DATA_BLOCKED = 0xA0
+
+
+class B8V2ErrorRebootDescription(IntEnum):
+    """Midea B8 v2 reboot-error description."""
+
+    NO = 0x00
+    REBOOT_LASER_COMM_FAIL = 0x01
+    REBOOT_ROBOT_COMM_FAIL = 0x02
+
+
+class B8V2ErrorWarningDescription(IntEnum):
+    """Midea B8 v2 warning-error description."""
+
+    NO = 0x00
+    WARN_LOCATION_FAIL = 0x01
+    WARN_LOW_BATTERY = 0x02
+    WARN_FULL_DUST = 0x03
+    WARN_LOW_WATER = 0x04
+    WARN_MULTIPLE_DOCKING_FAIL = 0x05
+    WARN_DOWN_SENSOR_BLOCKED = 0x06
+    WARN_ABNORMAL_BATTERY_TEMPERATURE = 0x07
+    WARN_RAG_LIFTING = 0x08
+    WARN_DUST_COLLECTION_INTERRUPT = 0x09
+    WARN_DUST_BLOCKAGE = 0x0A
+    WARN_UPPER_COVER_OPEN = 0x0B
+    WARN_DUST_BAG_NOT_INSTALLED = 0x0C
+    WARN_DUST_BAG_FULL = 0x0D
+    WARN_REACH_LOCATION_FAIL = 0x20
+    WARN_CACHE_FAIL = 0x21
+    WARN_START_MOP_IN_CARPET = 0x22
+    WARN_START_IN_VIRTUAL_WALL = 0x23
+    WARN_START_IN_FORBID_AREA = 0x24
+    WARN_START_IN_FORBID_WATER_AREA = 0x25
+    WARN_COMM_DISCONNECT = 0x64
+    WARN_MACHINE_MISS = 0x65
+    WARN_VACUUM_WATER_INJECT_FAIL = 0x66
+    WARN_SEWAGE_BOX_FULL = 0x67
+    WARN_SEWAGE_BOX_MISS = 0x68
+    WARN_WATER_BOX_MISS = 0x69
+    WARN_LACK_OF_WATER = 0x6A
+    WARN_CLOSE_POWER_FAIL = 0x6B
+    WARN_HEAT_MODULE_FAIL = 0x6C
+    WARN_FAN_FAIL = 0x6D
+    WARN_STATION_WATER_INJECT_FAIL = 0x6E
+    WARN_STATION_WATER_BOX_FULL = 0x6F
+    WARN_VACUUM_WATER_BOX_FULL = 0x70
+    WARN_VACUUM_WATER_BOX_MISS = 0x71
+    WARN_VACUUM_MOP_MISS = 0x72
+    WARN_WATER_SUPPLY_AND_DRAINAGE_IMPROPER_INSTALL = 0x75
+    WARN_BASE_STATION_WATER_LEVEL_FAILED_1 = 0x76
+    WARN_SLOP_TANK_EXCEPTION = 0x77
+    WARN_BASE_STATION_FILTER_NET_IMPROPER_INSTALL = 0x78
+    WARN_DUST_BOX_FULL = 0x79
+    WARN_DUST_BOX_COVER_NOT_CLOSED = 0x80
+    WARN_DUST_BAG_NOT_INSTALLED_2 = 0x81
+    WARN_CLEANING_LIQUID_LACK = 0x83
+    WARN_WATER_LEVEL_SENSOR_FAILED = 0x86
+    WARN_STRONG_LIQUID_LACK = 0x87
+    WARN_BASE_STATION_WATER_LEVEL_FAILED = 0x88
+    WARN_WASHER_BASE_STATION_COMMUNICATION_FAILED = 0xCC
+
+
+B8V2ErrorDescription = (
+    B8V2ErrorFixDescription | B8V2ErrorRebootDescription | B8V2ErrorWarningDescription
+)
+
+
+class MessageB8V2Base(MessageRequest):
+    """B8 v2 message base (body-type ``0xAA``)."""
+
+    def __init__(
+        self,
+        protocol_version: int,
+        message_type: MessageType,
+    ) -> None:
+        """Initialize B8 v2 message base."""
+        super().__init__(
+            device_type=DeviceType.B8,
+            protocol_version=protocol_version,
+            message_type=message_type,
+            body_type=ListTypes.AA,
+        )
+
+    @property
+    def _body(self) -> bytearray:
+        raise NotImplementedError
+
+
+class MessageV2Query(MessageB8V2Base):
+    """B8 v2 status query (``03 AA 01 <query_type>``)."""
+
+    def __init__(
+        self,
+        protocol_version: int,
+        query_type: B8V2QueryType = B8V2QueryType.WORK,
+    ) -> None:
+        """Initialize B8 v2 query."""
+        super().__init__(protocol_version, MessageType.query)
+        self.query_type = query_type
+
+    @property
+    def _body(self) -> bytearray:
+        return bytearray([0x01, self.query_type])
+
+
+class MessageV2SetCommand(MessageB8V2Base):
+    """B8 v2 task-control command (``02 AA 01 01 <task_control>``)."""
+
+    def __init__(
+        self,
+        protocol_version: int,
+        task_control: B8V2TaskControl,
+    ) -> None:
+        """Initialize B8 v2 task-control command."""
+        super().__init__(protocol_version, MessageType.set)
+        self.task_control = task_control
+
+    @property
+    def _body(self) -> bytearray:
+        return bytearray([0x01, 0x01, self.task_control])
+
+
+class MessageV2SetConfig(MessageB8V2Base):
+    """B8 v2 per-setting command (``02 AA 01 <config_type> <value>``)."""
+
+    def __init__(
+        self,
+        protocol_version: int,
+        config_type: B8V2ConfigType,
+        value: int,
+    ) -> None:
+        """Initialize B8 v2 per-setting command."""
+        super().__init__(protocol_version, MessageType.set)
+        self.config_type = config_type
+        self.value = value
+
+    @property
+    def _body(self) -> bytearray:
+        return bytearray([0x01, self.config_type, self.value])
+
+
+# Body byte offsets, counted from ``body[0]`` == frame byte 10 (body-type 0xAA).
+# body[1] = version 0x01, body[2] = query/report selector 0x01, data from body[3].
+_SELECTOR = 2
+_MIN_BODY_LEN = _SELECTOR + 1
+_WORK_STATUS = 3
+_CONTROL_TYPE = 5
+_MOVE_DIRECTION = 6
+_CLEAN_MODE = 7
+_FAN_LEVEL = 8
+_AREA = 9
+_WATER_LEVEL = 10
+_VOICE_VOLUME = 11
+_HAVE_RESERVE_TASK = 12
+_BATTERY_PERCENT = 13
+_WORK_TIME = 14
+_ERROR_TYPE = 16
+_ERROR_DESC = 17
+_MOP = 18
+_CARPET_SWITCH = 19
+_SWEEP_MOP_MODE = 34
+_SUB_WORK_STATUS = 36
+_STATUS_SUMMARY = 50
+
+
+_SUB_WORK_STATUS_ENUM: dict[B8V2WorkStatus, type[IntEnum]] = {
+    B8V2WorkStatus.ON_BASE: B8V2SubWorkStatus,
+    B8V2WorkStatus.SLEEP: B8V2SleepingStatus,
+    B8V2WorkStatus.RELOCATE: B8V2RelocateReason,
+}
+
+
+def _enum_or_zero[T: IntEnum](enum_cls: type[T], raw: int) -> T:
+    """Return ``enum_cls(raw)`` or the enum's ``0`` member on an unknown value."""
+    try:
+        return enum_cls(raw)
+    except ValueError:
+        return enum_cls(0)
+
+
+class MessageB8V2Body(MessageBody):
+    """B8 v2 work-status body (query reply ``03 AA 01 01`` / report ``04 .. 01``)."""
+
+    def __init__(self, body: bytearray) -> None:
+        """Parse a B8 v2 work-status body."""
+        super().__init__(body)
+        try:
+            self.work_status = B8V2WorkStatus(self.read_byte(body, _WORK_STATUS))
+        except ValueError:
+            self.work_status = B8V2WorkStatus.NONE
+        try:
+            self.control_type = B8ControlType(self.read_byte(body, _CONTROL_TYPE))
+        except ValueError:
+            self.control_type = B8ControlType.NONE
+        try:
+            self.move_direction = B8V2Moviment(self.read_byte(body, _MOVE_DIRECTION))
+        except ValueError:
+            self.move_direction = B8V2Moviment.NONE
+        try:
+            self.clean_mode = B8V2CleanMode(self.read_byte(body, _CLEAN_MODE))
+        except ValueError:
+            self.clean_mode = B8V2CleanMode.NONE
+        try:
+            self.fan_level = B8V2FanLevel(self.read_byte(body, _FAN_LEVEL))
+        except ValueError:
+            self.fan_level = B8V2FanLevel.NORMAL
+        self.area = self.read_byte(body, _AREA)
+        try:
+            self.water_level = B8V2WaterLevel(self.read_byte(body, _WATER_LEVEL))
+        except ValueError:
+            self.water_level = B8V2WaterLevel.LOW
+        self.voice_volume = min(self.read_byte(body, _VOICE_VOLUME), 100)
+        self.have_reserve_task = self.read_byte(body, _HAVE_RESERVE_TASK) != 0
+        self.battery_percent = min(self.read_byte(body, _BATTERY_PERCENT), 100)
+        self.work_time = self.read_byte(body, _WORK_TIME)
+
+        try:
+            self.error_type = B8ErrorType(self.read_byte(body, _ERROR_TYPE))
+        except ValueError:
+            self.error_type = B8ErrorType.NO
+        self.error_desc: B8V2ErrorDescription = self._parse_error_desc(
+            self.read_byte(body, _ERROR_DESC),
+        )
+
+        try:
+            self.mop = B8MopState(self.read_byte(body, _MOP))
+        except ValueError:
+            self.mop = B8MopState.LACK_WATER
+        self.carpet_switch = self.read_byte(body, _CARPET_SWITCH) != 0
+        try:
+            self.sweep_mop_mode = B8V2SweepMopMode(
+                self.read_byte(body, _SWEEP_MOP_MODE),
+            )
+        except ValueError:
+            self.sweep_mop_mode = B8V2SweepMopMode.SWEEP_AND_MOP
+        self.sub_work_status = self._parse_sub_work_status(
+            self.read_byte(body, _SUB_WORK_STATUS),
+        )
+
+        status_byte = self.read_byte(body, _STATUS_SUMMARY)
+        self.uv_switch = (status_byte & 0x01) > 0
+        self.wifi_switch = (status_byte & 0x02) > 0
+        self.voice_switch = (status_byte & 0x04) > 0
+        self.command_source = (status_byte & 0x40) > 0
+        self.device_error = (status_byte & 0x80) > 0
+
+    def _parse_error_desc(self, raw: int) -> B8V2ErrorDescription:
+        table: dict[B8ErrorType, type[B8V2ErrorDescription]] = {
+            B8ErrorType.CAN_FIX: B8V2ErrorFixDescription,
+            B8ErrorType.REBOOT: B8V2ErrorRebootDescription,
+            B8ErrorType.WARNING: B8V2ErrorWarningDescription,
+        }
+        enum_cls = table.get(self.error_type)
+        if enum_cls is None:
+            return B8V2ErrorFixDescription.NO
+        return _enum_or_zero(enum_cls, raw)
+
+    def _parse_sub_work_status(self, raw: int) -> str:
+        enum_cls = _SUB_WORK_STATUS_ENUM.get(self.work_status)
+        if enum_cls is None:
+            return "none"
+        try:
+            return enum_cls(raw).name.lower()
+        except ValueError:
+            return "none"
+
+
+class MessageB8V2Response(MessageResponse):
+    """B8 v2 message response."""
+
+    def __init__(self, message: bytes) -> None:
+        """Initialize B8 v2 message response."""
+        super().__init__(bytearray(message))
+        body = MessageB8V2Response.parse_body(
+            MessageType(self.message_type),
+            super().body,
+        )
+        if body is not None:
+            self.set_body(body)
+            self.set_attr()
+
+    @staticmethod
+    def parse_body(message_type: MessageType, body: bytearray) -> MessageBody | None:
+        """Parse body."""
+        if len(body) < _MIN_BODY_LEN or body[0] != ListTypes.AA:
+            return None
+        selector = body[_SELECTOR]
+        if (message_type == MessageType.query and selector == B8V2QueryType.WORK) or (
+            message_type == MessageType.notify1 and selector == 0x01
+        ):
+            return MessageB8V2Body(body)
+        return None

--- a/tests/devices/b8/device_b8_v2_test.py
+++ b/tests/devices/b8/device_b8_v2_test.py
@@ -1,0 +1,371 @@
+"""Test B8 second-generation ("v2") protocol support."""
+
+from unittest.mock import patch
+
+import pytest
+
+from midealocal.const import ProtocolVersion
+from midealocal.devices import b8
+from midealocal.devices.b8 import (
+    B8WorkMode,
+    DeviceAttributes,
+    MideaB8Device,
+)
+from midealocal.devices.b8.message import MessageQuery
+from midealocal.devices.b8.message_v2 import (
+    B8V2ConfigType,
+    B8V2FanLevel,
+    B8V2TaskControl,
+    B8V2WaterLevel,
+    MessageB8V2Response,
+    MessageV2Query,
+    MessageV2SetCommand,
+    MessageV2SetConfig,
+)
+from midealocal.message import ListTypes, MessageType
+
+_V2_SUBTYPE = 999
+
+
+def _v2_frame(
+    values: dict[int, int],
+    *,
+    message_type: MessageType = MessageType.query,
+    selector: int = 0x01,
+    length: int = 52,
+) -> bytes:
+    """Build a synthetic B8 v2 response frame.
+
+    ``values`` maps body-byte index (``body[0]`` == frame byte 10) to value.
+    """
+    header = bytearray([0xAA] + [0x0] * 7 + [ProtocolVersion.V1, message_type])
+    body = bytearray(length)
+    for index, value in ({0: ListTypes.AA, 1: 0x01, 2: selector} | values).items():
+        if index < length:
+            body[index] = value
+    return bytes(header + body + bytearray([0x0]))  # trailing checksum byte
+
+
+class TestMideaB8DeviceV2:
+    """Test the v2 code paths of MideaB8Device."""
+
+    device: MideaB8Device
+
+    @pytest.fixture(autouse=True)
+    def _setup_device(self) -> None:
+        self.device = MideaB8Device(
+            name="Test Device",
+            device_id=1,
+            ip_address="192.168.1.1",
+            port=12345,
+            token="AA",
+            key="BB",
+            device_protocol=ProtocolVersion.V1,
+            model="test_model",
+            subtype=_V2_SUBTYPE,
+            customize="",
+        )
+
+    @pytest.fixture
+    def _enable_v2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(b8, "_V2_SUBTYPES", frozenset({_V2_SUBTYPE}))
+
+    def test_v2_inactive_by_default(self) -> None:
+        """Without a matching subtype the device keeps the v1 protocol."""
+        assert self.device._is_v2 is False
+        assert isinstance(self.device.build_query()[0], MessageQuery)
+
+    @pytest.mark.usefixtures("_enable_v2")
+    def test_v2_active_for_listed_subtype(self) -> None:
+        """A listed subtype switches every entry point to v2."""
+        assert self.device._is_v2 is True
+        queries = self.device.build_query()
+        assert len(queries) == 1
+        assert isinstance(queries[0], MessageV2Query)
+        assert queries[0].body == bytearray([ListTypes.AA, 0x01, 0x01])
+
+    @pytest.mark.usefixtures("_enable_v2")
+    def test_v2_work_status_response(self) -> None:
+        """A v2 work-status frame updates the shared attributes."""
+        frame = _v2_frame(
+            {
+                3: 0x05,  # work_status WORK
+                5: 0x02,  # control_type AUTO
+                7: 0x08,  # clean_mode AUTO
+                8: 0x02,  # fan_level HIGH
+                9: 12,  # area
+                10: 0x02,  # water_level NORMAL
+                11: 40,  # voice_volume
+                12: 1,  # have_reserve_task
+                13: 77,  # battery_percent
+                14: 20,  # work_time
+                18: 0x01,  # mop ON
+                19: 1,  # carpet_switch
+                34: 0x01,  # sweep_mop_mode SWEEP
+                50: 0xC7,  # uv+wifi+voice+command_source+device_error
+            },
+        )
+        self.device.process_message(frame)
+        attrs = self.device.attributes
+        assert attrs[DeviceAttributes.work_status] == "work"
+        assert attrs[DeviceAttributes.sub_work_status] == "none"
+        assert attrs[DeviceAttributes.sweep_mop_mode] == "sweep"
+        assert attrs[DeviceAttributes.control_type] == "auto"
+        assert attrs[DeviceAttributes.clean_mode] == "auto"
+        assert attrs[DeviceAttributes.fan_level] == "high"
+        assert attrs[DeviceAttributes.area] == 12
+        assert attrs[DeviceAttributes.water_level] == "normal"
+        assert attrs[DeviceAttributes.voice_volume] == 40
+        assert attrs[DeviceAttributes.have_reserve_task] is True
+        assert attrs[DeviceAttributes.battery_percent] == 77
+        assert attrs[DeviceAttributes.work_time] == 20
+        assert attrs[DeviceAttributes.error_type] == "no"
+        assert attrs[DeviceAttributes.error_desc] == "no"
+        assert attrs[DeviceAttributes.mop] == "on"
+        assert attrs[DeviceAttributes.carpet_switch] is True
+        assert attrs[DeviceAttributes.uv_switch] is True
+        assert attrs[DeviceAttributes.wifi_switch] is True
+        assert attrs[DeviceAttributes.voice_switch] is True
+        assert attrs[DeviceAttributes.command_source] is True
+        assert attrs[DeviceAttributes.device_error] is True
+
+    @pytest.mark.usefixtures("_enable_v2")
+    @pytest.mark.parametrize(
+        ("work_status", "sub_byte", "expected"),
+        [
+            pytest.param(0x12, 0x03, "clean_mop", id="on_base"),
+            pytest.param(0x0A, 0x31, "pause_sleeping", id="sleep"),
+            pytest.param(0x0B, 0x52, "wheel_lift", id="relocate"),
+            pytest.param(0x05, 0x03, "none", id="work-has-no-sub"),
+            pytest.param(0x12, 0xEE, "none", id="unknown-sub-code"),
+        ],
+    )
+    def test_v2_sub_work_status(
+        self,
+        work_status: int,
+        sub_byte: int,
+        expected: str,
+    ) -> None:
+        """The sub-status byte is decoded against the table for the work state."""
+        self.device.process_message(_v2_frame({3: work_status, 36: sub_byte}))
+        assert self.device.attributes[DeviceAttributes.sub_work_status] == expected
+
+    @pytest.mark.usefixtures("_enable_v2")
+    @pytest.mark.parametrize(
+        ("error_type", "desc_byte", "expected_type", "expected_desc"),
+        [
+            pytest.param(
+                0x01,
+                0x14,
+                "can_fix",
+                "fix_vibration_drag_overload",
+                id="fix",
+            ),
+            pytest.param(0x02, 0x01, "reboot", "reboot_laser_comm_fail", id="reboot"),
+            pytest.param(
+                0x03,
+                0xCC,
+                "warning",
+                "warn_washer_base_station_communication_failed",
+                id="warn",
+            ),
+            pytest.param(0x01, 0xFD, "can_fix", "no", id="unknown-fix-code"),
+            pytest.param(0x00, 0x14, "no", "no", id="no-error"),
+        ],
+    )
+    def test_v2_error_desc(
+        self,
+        error_type: int,
+        desc_byte: int,
+        expected_type: str,
+        expected_desc: str,
+    ) -> None:
+        """The error description byte is decoded against the error-type table."""
+        self.device.process_message(_v2_frame({16: error_type, 17: desc_byte}))
+        assert self.device.attributes[DeviceAttributes.error_type] == expected_type
+        assert self.device.attributes[DeviceAttributes.error_desc] == expected_desc
+
+    @pytest.mark.usefixtures("_enable_v2")
+    def test_v2_invalid_enum_fallbacks(self) -> None:
+        """Out-of-range enum bytes fall back to defaults without dropping scalars."""
+        frame = _v2_frame(
+            {
+                3: 0x7F,  # invalid work_status
+                5: 0x7F,  # invalid control_type
+                6: 0x7F,  # invalid move_direction
+                7: 0x7F,  # invalid clean_mode
+                8: 0x7F,  # invalid fan_level
+                9: 33,  # area preserved
+                10: 0x7F,  # invalid water_level
+                16: 0x7F,  # invalid error_type
+                18: 0x7F,  # invalid mop state
+                34: 0x7F,  # invalid sweep_mop_mode
+            },
+        )
+        self.device.process_message(frame)
+        attrs = self.device.attributes
+        assert attrs[DeviceAttributes.work_status] == "none"
+        assert attrs[DeviceAttributes.control_type] == "none"
+        assert attrs[DeviceAttributes.move_direction] == "none"
+        assert attrs[DeviceAttributes.clean_mode] == "none"
+        assert attrs[DeviceAttributes.fan_level] == "normal"
+        assert attrs[DeviceAttributes.water_level] == "low"
+        assert attrs[DeviceAttributes.error_type] == "no"
+        assert attrs[DeviceAttributes.mop] == "lack_water"
+        assert attrs[DeviceAttributes.sweep_mop_mode] == "sweep_and_mop"
+        assert attrs[DeviceAttributes.area] == 33
+
+    @pytest.mark.usefixtures("_enable_v2")
+    @pytest.mark.parametrize(
+        ("work_mode", "expected_task"),
+        [
+            pytest.param(B8WorkMode.CHARGE, B8V2TaskControl.CHARGE, id="charge"),
+            pytest.param(B8WorkMode.WORK, B8V2TaskControl.WORK, id="work"),
+            pytest.param(B8WorkMode.STOP, B8V2TaskControl.STOP, id="stop"),
+            pytest.param(B8WorkMode.PAUSE, B8V2TaskControl.PAUSE, id="pause"),
+        ],
+    )
+    def test_v2_set_work_mode(
+        self,
+        work_mode: B8WorkMode,
+        expected_task: B8V2TaskControl,
+    ) -> None:
+        """v2 start/stop/charge/pause go through the task-control channel."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_work_mode(work_mode)
+        mock_send.assert_called_once()
+        msg = mock_send.call_args.args[0]
+        assert isinstance(msg, MessageV2SetCommand)
+        assert msg.task_control == expected_task
+        assert msg.body == bytearray([ListTypes.AA, 0x01, 0x01, expected_task])
+
+    @pytest.mark.usefixtures("_enable_v2")
+    def test_v2_set_work_mode_unmapped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A work mode with no v2 task-control equivalent emits nothing."""
+        monkeypatch.setattr(b8, "_WORK_MODE_TO_V2_TASK", {})
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_work_mode(B8WorkMode.WORK)
+        mock_send.assert_not_called()
+
+    @pytest.mark.usefixtures("_enable_v2")
+    @pytest.mark.parametrize(
+        ("attr", "value", "config_type", "expected_value"),
+        [
+            pytest.param(
+                DeviceAttributes.fan_level,
+                "super",
+                B8V2ConfigType.FAN,
+                B8V2FanLevel.SUPER,
+                id="fan",
+            ),
+            pytest.param(
+                DeviceAttributes.water_level,
+                "high",
+                B8V2ConfigType.WATER,
+                B8V2WaterLevel.HIGH,
+                id="water",
+            ),
+            pytest.param(
+                DeviceAttributes.voice_volume,
+                40,
+                B8V2ConfigType.VOICE,
+                40,
+                id="voice",
+            ),
+        ],
+    )
+    def test_v2_set_attribute(
+        self,
+        attr: DeviceAttributes,
+        value: str | int,
+        config_type: B8V2ConfigType,
+        expected_value: int,
+    ) -> None:
+        """Each v2 setting is sent as its own config frame."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(attr.value, value)
+        mock_send.assert_called_once()
+        msg = mock_send.call_args.args[0]
+        assert isinstance(msg, MessageV2SetConfig)
+        assert msg.config_type == config_type
+        assert msg.value == expected_value
+
+    @pytest.mark.usefixtures("_enable_v2")
+    @pytest.mark.parametrize(
+        ("attr", "value"),
+        [
+            pytest.param(DeviceAttributes.clean_mode, "auto", id="clean_mode"),
+            pytest.param(DeviceAttributes.fan_level, "invalid", id="invalid-value"),
+        ],
+    )
+    def test_v2_set_attribute_unsupported(
+        self,
+        attr: DeviceAttributes,
+        value: str,
+    ) -> None:
+        """Unsupported v2 attributes / bad values do not emit a frame."""
+        with patch.object(self.device, "build_send") as mock_send:
+            self.device.set_attribute(attr.value, value)
+        mock_send.assert_not_called()
+
+
+class TestMessageB8V2:
+    """Test the v2 message classes directly."""
+
+    def test_query_body(self) -> None:
+        """Query body is body-type, version, selector."""
+        msg = MessageV2Query(ProtocolVersion.V1)
+        assert msg.body == bytearray([ListTypes.AA, 0x01, 0x01])
+
+    def test_set_command_body(self) -> None:
+        """Task-control body carries the 0x01 0x01 prefix and the code."""
+        msg = MessageV2SetCommand(ProtocolVersion.V1, B8V2TaskControl.PAUSE)
+        assert msg.body == bytearray([ListTypes.AA, 0x01, 0x01, 0x05])
+
+    def test_set_config_body(self) -> None:
+        """Config body carries the selector and value."""
+        msg = MessageV2SetConfig(
+            ProtocolVersion.V1,
+            B8V2ConfigType.FAN,
+            B8V2FanLevel.SUPER,
+        )
+        assert msg.body == bytearray([ListTypes.AA, 0x01, 0x50, 0x03])
+
+    @pytest.mark.parametrize(
+        ("message_type", "selector", "length", "expected"),
+        [
+            pytest.param(MessageType.query, 0x01, 52, True, id="query-work"),
+            pytest.param(MessageType.notify1, 0x01, 52, True, id="notify-report"),
+            pytest.param(MessageType.query, 0x50, 52, False, id="other-selector"),
+            pytest.param(MessageType.set, 0x01, 52, False, id="set-not-parsed"),
+            pytest.param(MessageType.query, 0x01, 2, False, id="too-short"),
+        ],
+    )
+    def test_response_routing(
+        self,
+        message_type: MessageType,
+        selector: int,
+        length: int,
+        expected: bool,
+    ) -> None:
+        """parse_body only accepts AA-framed work/report bodies."""
+        frame = _v2_frame(
+            {3: 0x05},
+            message_type=message_type,
+            selector=selector,
+            length=length,
+        )
+        response = MessageB8V2Response(frame)
+        assert hasattr(response, "work_status") is expected
+
+    def test_response_ignores_non_aa_body(self) -> None:
+        """A non-0xAA body type is not a v2 frame."""
+        header = bytearray(
+            [0xAA] + [0x0] * 7 + [ProtocolVersion.V1, MessageType.query],
+        )
+        body = bytearray([ListTypes.X32, 0x01, 0x01] + [0x0] * 49)
+        response = MessageB8V2Response(bytes(header + body + bytearray([0x0])))
+        assert hasattr(response, "work_status") is False


### PR DESCRIPTION
Adds a parallel implementation of the newer B8 vacuum protocol (cloud plugin SN8 750004CE): body-type 0xAA frames, the renumbered work-status table, task-control start/stop/pause and per-setting config messages, and the sleep/relocate/on-base sub-status. Ported from lua/b8/T_0000_B8_750004CE_2024011101.lua.

Selected per device via `_V2_SUBTYPES`, which is empty for now — v2 stays inert until a real device's cloud `subType` is added, so existing 7500001H devices are unaffected.
