### PR TITLE
fix(b4): read water status flags from the correct body offset

### DIFF
--- a/midealocal/devices/b4/message.py
+++ b/midealocal/devices/b4/message.py
@@ -63,10 +63,12 @@ class B4MessageBody(MessageBody):
         if self.current_temperature == 0:
             self.current_temperature = (body[27] << 8) + body[28]
         self.status = body[31]
+        # door and the water flags share the same flag byte, matching the
+        # B1 X01 body (physically confirmed) and the BF body.
         self.door = (body[32] & 0x02) > 0
-        self.tank_ejected = (body[16] & 0x04) > 0
-        self.water_shortage = (body[16] & 0x08) > 0
-        self.water_change_reminder = (body[16] & 0x10) > 0
+        self.tank_ejected = (body[32] & 0x04) > 0
+        self.water_shortage = (body[32] & 0x08) > 0
+        self.water_change_reminder = (body[32] & 0x10) > 0
 
 
 class MessageB4Response(MessageResponse):

--- a/tests/devices/b4/device_b4_test.py
+++ b/tests/devices/b4/device_b4_test.py
@@ -56,14 +56,14 @@ class TestMideaB4Device:
         ) + bytearray([MessageType.query])
         body = bytearray(33)
         body[0] = 0x01  # body type
-        body[16] = 0x1C  # tank_ejected + water_shortage + change_reminder
         body[22] = 0x01  # hours
         body[23] = 0x01  # minutes
         body[24] = 0x01  # seconds
         body[25] = 0x01  # temperature high byte
         body[26] = 0x2C  # temperature low byte -> 300
         body[31] = 0x04  # status -> finished
-        body[32] = 0x02  # door
+        # door + tank_ejected + water_shortage + water_change_reminder
+        body[32] = 0x1E
         result = self.device.process_message(bytes(header + body + bytearray(1)))
         assert self.device.attributes[DeviceAttributes.door] is True
         assert self.device.attributes[DeviceAttributes.status] == "finished"


### PR DESCRIPTION
tank_ejected, water_shortage and water_change_reminder were decoded from
body[16], a copy-paste leftover from B1's X00 body layout. In the B4 X01
body these flags share the flag byte at body[32] with `door`, matching
B1's physically-confirmed X01 body and the BF body. Update the offset and
the test that asserted the wrong one.

Fixes #702