### PR TITLE
fix(cd): match controlType=0x01 SET body to lua/cd plugins

### DIFF
--- a/midealocal/devices/cd/__init__.py
+++ b/midealocal/devices/cd/__init__.py
@@ -765,38 +765,20 @@ class MideaCDDevice(MideaDevice):
             )
             return
 
-        # Power, mode, temperature, max_temperature, and vacation use controlType=0x01.
+        # Power, mode, temperature and vacation use controlType=0x01.
+        # max_temperature (tsMax) and schedule_mode are read-only: no Midea CD
+        # Lua plugin writes them in any SET body.
         if attr in [
             DeviceAttributes.mode,
             DeviceAttributes.power,
             DeviceAttributes.target_temperature,
             DeviceAttributes.vacation_mode,
             DeviceAttributes.vacation_days,
-            DeviceAttributes.max_temperature,
-            DeviceAttributes.schedule_mode,
         ]:
-            if (
-                attr
-                in {
-                    DeviceAttributes.max_temperature,
-                    DeviceAttributes.schedule_mode,
-                }
-                and not self._is_extended_water_heater()
-            ):
-                _LOGGER.warning(
-                    "[%s] %s write requires reported CD support",
-                    self.device_id,
-                    attr,
-                )
-                return
             message = MessageSet(self._message_protocol_version)
             message.fields = dict(self._fields) if self._fields else {}
             # align temperature encoding with lua protocol selection
             message.use_old_protocol = self._lua_protocol == LuaProtocol.old
-            schedule_mode = self._attributes.get(DeviceAttributes.schedule_mode)
-            message.schedule_mode = (
-                int(schedule_mode) if isinstance(schedule_mode, int | float) else 0
-            )
 
             # Get safe current values
             current_power = self._attributes.get(DeviceAttributes.power, False)
@@ -813,8 +795,7 @@ class MideaCDDevice(MideaDevice):
                 self._attributes.get(DeviceAttributes.fahrenheit, False),
             )
 
-            # full[21] vacationTsValue — not max temperature.
-            # full[23] tsMax — must be the device max (issue #468); 0 clamps SP.
+            # full[21] vacationTsValue — only sent for vacation controls.
             if attr in (
                 DeviceAttributes.target_temperature,
                 DeviceAttributes.mode,
@@ -829,13 +810,6 @@ class MideaCDDevice(MideaDevice):
                     if isinstance(vac_temp, int | float) and vac_temp > 0
                     else 0.0
                 )
-            mx = self._attributes.get(DeviceAttributes.max_temperature)
-            try:
-                message.ts_max = (
-                    int(mx) if isinstance(mx, int | float) and mx > 0 else 0
-                )
-            except (TypeError, ValueError):
-                message.ts_max = 0
 
             # Ensure temperature is valid (not None/0)
             if isinstance(current_temp, int | float) and current_temp > 0:
@@ -920,24 +894,6 @@ class MideaCDDevice(MideaDevice):
                 days = max(1, min(360, int(value)))
                 message.vacation_flag = True
                 message.vacation_days = days
-
-            elif attr == DeviceAttributes.max_temperature:
-                # max_temperature is the configurable tsMax setting; the
-                # immutable device bounds are reported by the two limit attrs.
-                lower = self._attributes.get(
-                    DeviceAttributes.max_temperature_lower_limit,
-                )
-                upper = self._attributes.get(
-                    DeviceAttributes.max_temperature_upper_limit,
-                )
-                minimum = int(lower) if isinstance(lower, int | float) else 35
-                maximum = int(upper) if isinstance(upper, int | float) else 70
-                message.ts_max = max(minimum, min(maximum, int(float(value))))
-                if message.target_temperature > message.ts_max:
-                    message.target_temperature = float(message.ts_max)
-
-            elif attr == DeviceAttributes.schedule_mode:
-                message.schedule_mode = max(0, min(2, int(value)))
 
             # persist only safe fields; SET echoes often return openPTC=1 / bad Tr
             self._fields = self._sanitize_set_fields(message.fields)

--- a/midealocal/devices/cd/message.py
+++ b/midealocal/devices/cd/message.py
@@ -218,33 +218,40 @@ class MessageQueryB1(MessageCDBase):
 class MessageSet(MessageCDBase):
     """CD message set (controlType=0x01).
 
-    RSJRAC07 / extended Lua (T_0000_CD_RSJRAC07) expects a **25-byte** control
-    body (body_type + 24-byte payload). A shorter body faults the unit: target
-    and max temperature become 0 until power-cycled or restored via the app.
+    The body matches Midea's own CD Lua plugins. Their ``jsonToData``
+    ``controlType == 0x01`` branch builds the SET body as:
+
+      * ``lua/cd/T_0000_CD_RSJRAC01_2023070401.lua`` / ``T_0000_CD_14.lua`` and
+        the ``T_0000_CD_RSJ000CB_*`` plugins (new, raw-°C protocol):
+        ``bodyBytes[0..21]`` — a 22-byte body (body_type + 21-byte payload),
+        last field ``bodyBytes[21] = vacationTsValue``.
+      * ``T_0000_CD_3/7/000K86A2_3`` (old ``x2+30`` protocol):
+        ``bodyBytes[0..8]`` — a 9-byte body.
+
+    None of the plugins write a byte past ``bodyBytes[21]``; there is no
+    ``tsMax``/``timer_type``/``dr_switch`` in the SET path (``tsMaxValue`` is
+    read-only, decoded from the status body). Sending the historical 8-byte
+    body to a new-protocol RSJRAC unit faults it (setpoint sticks at 0) until a
+    power-cycle. See https://github.com/midea-lan/midea-local/issues/468
 
     Layout (after MessageRequest prepends body_type at full[0]):
-      full[1]  = 0x01 constant
-      full[2]  = power
-      full[3]  = mode (1 eco, 2 standard, 3 dual/compatibilizing, 4 smart, ...)
-      full[4]  = target temperature (raw °C for new protocol)
-      full[5]  = trValue (hysteresis; Lua range 2-6)
-      full[6]  = openPTC (Lua forces 0 on normal sets)
-      full[7]  = ptcTemp
-      full[8]  = flags (vacation 0x10 / °F 0x80 / mute 0x08)
-      full[9..20] = vacation days + date fields (0 for a plain set)
-      full[21] = vacationTsValue
-      full[22] = timer_type
-      full[23] = **tsMax** (device max temperature; must not be 0)
-      full[24] = dr_switch
-
-    See https://github.com/midea-lan/midea-local/issues/468
+      full[1]      = 0x01 constant
+      full[2]      = power
+      full[3]      = mode (1 energy · 2 standard · 3 compatibilizing · 4 smart)
+      full[4]      = target temperature (raw °C new protocol, x2+30 old)
+      full[5]      = trValue (hysteresis; Lua range 2-6)
+      full[6]      = openPTC (forced 0 on plain sets, see _sanitize_set_fields)
+      full[7]      = ptcTemp
+      full[8]      = flags (vacation 0x10 / °F 0x80 / mute 0x08)
+      full[9..10]  = vacation days (big-endian)
+      full[11..20] = date / vacation-start fields (0 for a plain set)
+      full[21]     = vacationTsValue
     """
 
     DEFAULT_VACATION_DAYS = 100
     TR_VALUE_MIN = 2
     TR_VALUE_MAX = 6
     DEFAULT_TR_VALUE = 5
-    DEFAULT_TS_MAX = 65
 
     def __init__(self, protocol_version: int) -> None:
         """Initialize CD message set."""
@@ -268,9 +275,6 @@ class MessageSet(MessageCDBase):
         self.fahrenheit: bool = False
         # vacation target temperature (full[21] / vacationTsValue)
         self.vacation_temperature: float = 0
-        # device max temperature limit (full[23] / tsMax) — must be non-zero
-        self.ts_max: int = 0
-        self.schedule_mode: int = 0
 
     def read_field(self, field: str) -> int:
         """CD message set read field."""
@@ -283,16 +287,6 @@ class MessageSet(MessageCDBase):
         if tr < self.TR_VALUE_MIN or tr > self.TR_VALUE_MAX:
             return self.DEFAULT_TR_VALUE
         return tr
-
-    def _ts_max_value(self) -> int:
-        """Return tsMax; never 0 (firmware clamps setpoint when tsMax is 0)."""
-        try:
-            value = int(self.ts_max)
-        except (TypeError, ValueError):
-            value = 0
-        if value <= 0:
-            return self.DEFAULT_TS_MAX
-        return value & 0xFF
 
     @property
     def _body(self) -> bytearray:
@@ -324,7 +318,7 @@ class MessageSet(MessageCDBase):
         ):
             vacation_ts = int(self.vacation_temperature) & 0xFF
 
-        # 24-byte payload; MessageRequest prepends body_type → 25-byte body
+        # 21-byte payload; MessageRequest prepends body_type → 22-byte body
         return bytearray(
             [
                 0x01,  # full[1] constant
@@ -332,7 +326,7 @@ class MessageSet(MessageCDBase):
                 mode,  # full[3]
                 int(target_temperature) & 0xFF,  # full[4]
                 self._tr_value() & 0xFF,  # full[5]
-                0x00,  # full[6] openPTC forced 0 (Lua normal set)
+                0x00,  # full[6] openPTC forced 0 (see _sanitize_set_fields)
                 self.read_field("ptcTemp") & 0xFF,  # full[7]
                 byte8 & 0xFF,  # full[8]
                 vacation_high,  # full[9]
@@ -348,9 +342,6 @@ class MessageSet(MessageCDBase):
                 0,  # full[19]
                 0,  # full[20]
                 vacation_ts,  # full[21] vacationTsValue
-                self.schedule_mode & 0xFF,  # full[22] schedule mode
-                self._ts_max_value(),  # full[23] tsMax (must be non-zero)
-                0x00,  # full[24] dr_switch
             ],
         )
 

--- a/tests/devices/cd/device_cd_test.py
+++ b/tests/devices/cd/device_cd_test.py
@@ -86,7 +86,7 @@ class TestMideaCDDevice:
         )
 
     # ------------------------------------------------------------------ #
-    # MessageSet 25-byte body / tsMax (issue #468)                        #
+    # MessageSet controlType=0x01 SET body (issue #468)                   #
     # ------------------------------------------------------------------ #
 
     def test_preset_modes_excludes_vacation_from_selectable_modes(self) -> None:
@@ -100,8 +100,8 @@ class TestMideaCDDevice:
             self.device.set_attribute(DeviceAttributes.mode.value, "vacation")
             mock_send.assert_not_called()
 
-    def test_set_power_uses_ts_max_at_body_23(self) -> None:
-        """Plain SET uses device max_temperature as full[23] tsMax (#468)."""
+    def test_set_power_builds_lua_length_body(self) -> None:
+        """Plain SET builds the 22-byte lua/cd body, vacationTs left 0 (#468)."""
         self.device._attributes[DeviceAttributes.max_temperature] = 70.0
         self.device._attributes[DeviceAttributes.vacation_temperature] = 65.0
 
@@ -109,14 +109,12 @@ class TestMideaCDDevice:
             self.device.set_attribute(DeviceAttributes.power.value, True)
             mock_send.assert_called_once()
             msg = mock_send.call_args[0][0]
-            assert msg.ts_max == 70
-            assert len(msg.body) == 25
-            assert msg.body[23] == 70  # tsMax
+            assert len(msg.body) == 22
             assert msg.body[21] == 0  # vacationTs left 0 on plain set
             assert msg.body[4] != 0  # target present
 
-    def test_set_target_temperature_body_length_and_ts_max(self) -> None:
-        """set_temperature builds 25-byte body with non-zero tsMax."""
+    def test_set_target_temperature_body_length(self) -> None:
+        """set_temperature builds the 22-byte new-protocol body (#468)."""
         # RSJRAC07 uses the new (raw °C) Lua protocol — matches issue #468.
         self.device.set_customize('{"lua_protocol": "new"}')
         self.device._attributes[DeviceAttributes.max_temperature] = 65.0
@@ -130,13 +128,11 @@ class TestMideaCDDevice:
             msg = mock_send.call_args[0][0]
             assert msg.target_temperature == 63.0
             assert msg.use_old_protocol is False
-            assert len(msg.body) == 25
+            assert len(msg.body) == 22
             assert msg.body[4] == 63
-            assert msg.body[23] == 65
 
     def test_disable_vacation_sets_flag_and_mode(self) -> None:
         """Disabling vacation clears flag and forces Energy-save mode."""
-        self.device._attributes[DeviceAttributes.max_temperature] = 65.0
         self.device._attributes[DeviceAttributes.vacation_mode] = True
 
         with patch.object(self.device, "build_send") as mock_send:
@@ -146,12 +142,9 @@ class TestMideaCDDevice:
             assert msg.vacation_flag is False
             assert msg.vacation_days == 0
             assert msg.mode == 0x01
-            assert msg.body[23] == 65
 
     def test_set_vacation_days_encodes_days(self) -> None:
-        """vacation_days SET keeps tsMax and marks vacation flag."""
-        self.device._attributes[DeviceAttributes.max_temperature] = 65.0
-
+        """vacation_days SET marks the vacation flag and encodes the day count."""
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.vacation_days.value, 30)
             mock_send.assert_called_once()
@@ -159,36 +152,6 @@ class TestMideaCDDevice:
             assert msg.vacation_flag is True
             assert msg.vacation_days == 30
             assert msg.body[10] == 30  # vacation days low
-            assert msg.body[23] == 65
-
-    def test_ts_max_falls_back_when_max_missing(self) -> None:
-        """Missing max_temperature still yields non-zero tsMax via MessageSet."""
-        self.device._attributes[DeviceAttributes.max_temperature] = None
-
-        with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.power.value, True)
-            mock_send.assert_called_once()
-            msg = mock_send.call_args[0][0]
-            assert msg.body[23] != 0
-
-    def test_ts_max_falls_back_when_max_unconvertible(self) -> None:
-        """A stored max_temperature that fails int() conversion sends tsMax=0."""
-
-        class UnconvertibleFloat(float):
-            """A float that raises when int() is attempted on it."""
-
-            def __int__(self) -> int:
-                raise ValueError("cannot convert")
-
-        self.device._attributes[DeviceAttributes.max_temperature] = UnconvertibleFloat(
-            70.0,
-        )
-
-        with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.power.value, True)
-            mock_send.assert_called_once()
-            msg = mock_send.call_args[0][0]
-            assert msg.ts_max == 0
 
     # ------------------------------------------------------------------ #
     # disinfect set_attribute                                              #
@@ -291,8 +254,8 @@ class TestMideaCDDevice:
     # max_temperature                                                       #
     # ------------------------------------------------------------------ #
 
-    def test_set_max_temperature_sends_clamped_message(self) -> None:
-        """max_temperature is read-only until the write payload is safe."""
+    def test_set_max_temperature_is_read_only(self) -> None:
+        """max_temperature (tsMax) is read-only: no CD Lua writes it (#468)."""
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.max_temperature.value, 70.0)
             mock_send.assert_not_called()
@@ -936,25 +899,14 @@ class TestMideaCDExtendedDevice:
         message = mock_send.call_args.args[0]
         assert message.mode == 0x05
 
-    def test_max_temperature_is_clamped_to_reported_limit(self) -> None:
-        """Maximum target temperature uses BasicControl byte 23."""
+    def test_max_temperature_and_schedule_mode_are_read_only(self) -> None:
+        """Neither tsMax nor schedule_mode is writable — no CD Lua sends them."""
         self.device._attributes[DeviceAttributes.max_temperature_lower_limit] = 40.0
         self.device._attributes[DeviceAttributes.max_temperature_upper_limit] = 68.0
         with patch.object(self.device, "build_send") as mock_send:
             self.device.set_attribute(DeviceAttributes.max_temperature.value, 75.0)
-        message = mock_send.call_args.args[0]
-        assert message.body[23] == 68
-
-    def test_max_temperature_clamps_target_and_schedule_mode(self) -> None:
-        """Reducing the maximum also clamps target; schedule mode stays 0..2."""
-        self.device._attributes[DeviceAttributes.target_temperature] = 69.0
-        with patch.object(self.device, "build_send") as mock_send:
-            self.device.set_attribute(DeviceAttributes.max_temperature.value, 65.0)
-            maximum = mock_send.call_args.args[0]
-            assert maximum.target_temperature == 65.0
             self.device.set_attribute(DeviceAttributes.schedule_mode.value, 9.0)
-            schedule = mock_send.call_args.args[0]
-            assert schedule.schedule_mode == 2
+        mock_send.assert_not_called()
 
     def test_maintenance_preserves_b1_flags(self) -> None:
         """Maintenance B0 control preserves priority, warning and reserved bits."""

--- a/tests/devices/cd/message_cd_test.py
+++ b/tests/devices/cd/message_cd_test.py
@@ -1,7 +1,5 @@
 """Test CD message."""
 
-from typing import Any
-
 import pytest
 
 from midealocal.const import ProtocolVersion
@@ -83,7 +81,8 @@ class TestMessageSet:
         assert body[8] == 0x00  # flags
         assert body[9] == 0x00
         assert body[10] == 0x00
-        assert body[21] == 0  # max_temperature
+        assert len(body) == 22  # body_type + 21-byte payload (lua/cd)
+        assert body[21] == 0  # vacationTsValue (last field)
 
     def test_old_protocol_temperature(self) -> None:
         """Old protocol doubles the temperature and adds 30."""
@@ -125,11 +124,10 @@ class TestMessageSet:
         assert msg.read_field("openPTC") == 0
         assert msg.read_field("missing") == 0
 
-    def test_schedule_mode_uses_basic_control_byte_22(self) -> None:
-        """Timer/schedule selection is preserved in ordinary controls."""
+    def test_body_stops_at_vacation_ts_value(self) -> None:
+        """No Midea CD Lua writes past bodyBytes[21]; the body ends there."""
         msg = MessageSet(protocol_version=ProtocolVersion.V1)
-        msg.schedule_mode = 2
-        assert msg.body[22] == 2
+        assert len(msg.body) == 22
 
 
 class TestMessageSetMaintenance:
@@ -717,43 +715,23 @@ class TestMessageSetSterilize:
 
 
 class TestMessageSetRsjracBody:
-    """Regression tests for CD controlType=0x01 25-byte SET body (#468)."""
+    """Regression tests for the CD controlType=0x01 SET body (#468).
 
-    def test_body_length_is_25_with_type(self) -> None:
-        """MessageSet.body is body_type + 24-byte payload."""
+    The body matches Midea's own CD Lua plugins: 22 bytes (body_type + 21-byte
+    payload) for the new protocol, ending at bodyBytes[21] = vacationTsValue.
+    """
+
+    def test_body_length_is_22_with_type(self) -> None:
+        """MessageSet.body is body_type + 21-byte payload, raw °C target."""
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x02
         msg.target_temperature = 63
         msg.use_old_protocol = False
-        msg.ts_max = 65
         body = msg.body
-        assert len(body) == 25
+        assert len(body) == 22
         assert body[0] == 0x01
         assert body[4] == 63
-        assert body[23] == 65
-        assert body[24] == 0
-
-    def test_ts_max_zero_falls_back(self) -> None:
-        """Zero tsMax falls back to the default (never emitted as 0)."""
-        msg = MessageSet(protocol_version=8)
-        msg.power = True
-        msg.mode = 0x01
-        msg.target_temperature = 60
-        msg.use_old_protocol = False
-        msg.ts_max = 0
-        assert msg.body[23] == MessageSet.DEFAULT_TS_MAX
-
-    def test_ts_max_unparseable_falls_back(self) -> None:
-        """A non-numeric tsMax falls back to the default instead of raising."""
-        msg = MessageSet(protocol_version=8)
-        msg.power = True
-        msg.mode = 0x01
-        msg.target_temperature = 60
-        msg.use_old_protocol = False
-        bad_ts_max: Any = "abc"
-        msg.ts_max = bad_ts_max
-        assert msg.body[23] == MessageSet.DEFAULT_TS_MAX
 
     def test_tr_clamped(self) -> None:
         """Out-of-range Tr is clamped to default 5."""
@@ -762,7 +740,6 @@ class TestMessageSetRsjracBody:
         msg.mode = 0x01
         msg.target_temperature = 60
         msg.use_old_protocol = False
-        msg.ts_max = 65
         msg.fields = {"trValue": 13}
         assert msg.body[5] == 5
 
@@ -773,18 +750,16 @@ class TestMessageSetRsjracBody:
         msg.mode = 0x02
         msg.target_temperature = 63
         msg.use_old_protocol = False
-        msg.ts_max = 65
         msg.fields = {"openPTC": 1, "trValue": 5}
         assert msg.body[6] == 0
 
     def test_vacation_days_in_body(self) -> None:
-        """Vacation SET encodes days in full[9..10]."""
+        """Vacation SET encodes days in full[9..10] and vacationTs in full[21]."""
         msg = MessageSet(protocol_version=8)
         msg.power = True
         msg.mode = 0x01
         msg.target_temperature = 50
         msg.use_old_protocol = False
-        msg.ts_max = 65
         msg.vacation_flag = True
         msg.vacation_days = 30
         msg.vacation_temperature = 50
@@ -792,7 +767,6 @@ class TestMessageSetRsjracBody:
         assert body[9] == 0
         assert body[10] == 30
         assert body[21] == 50
-        assert body[23] == 65
 
 
 class TestCDGeneralMessageBodySynthetic:


### PR DESCRIPTION
Every lua/cd plugin builds the controlType=0x01 SET body as at most bodyBytes[0..21] (22-byte body ending at vacationTsValue). tsMaxValue is read-only in all of them, and none write timer_type/dr_switch/schedule_mode in the SET path.

- trim MessageSet._body to the 21-byte payload; drop ts_max, _ts_max_value,
  DEFAULT_TS_MAX and schedule_mode
- make max_temperature (tsMax) and schedule_mode read-only: remove their
  controlType=0x01 write branches in set_attribute
- keep openPTC-forced-0, Tr clamp [2,6], vacation-day encoding and
  _sanitize_set_fields from #497

This replaces the speculative 25-byte body (#497/#735) that was based on an RSJRAC07 Lua not present in the repo; the repo's RSJRAC01/RSJ000CB plugins use the 22-byte body.

Closes #468
